### PR TITLE
Fix for older SDK versions.

### DIFF
--- a/PowerSync/PowerSync.Common/DB/Schema/Table.cs
+++ b/PowerSync/PowerSync.Common/DB/Schema/Table.cs
@@ -81,8 +81,10 @@ public class Table
             columnNames.Add(columnName);
         }
 
-        foreach (var (indexName, indexColumns) in Indexes)
+        foreach (var kvp in Indexes)
         {
+            var indexName = kvp.Key;
+            var indexColumns = kvp.Value;
 
             if (InvalidSQLCharacters.IsMatch(indexName))
             {


### PR DESCRIPTION
Seems like this syntax didn't play well during release.
Will need to add another build step soon.