### PR TITLE
feat: Expose upload/download errors, credential management, last synced value from core extension

### DIFF
--- a/PowerSync/PowerSync.Common/CHANGELOG.md
+++ b/PowerSync/PowerSync.Common/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.2-alpha.2
+
+- Updated core extension to v0.3.14
+- Loading last synced time from core extension
+- Expose upload and download errors on SyncStatus
+- Improved credentials management and error handling. Credentials are invalidated when they expire or become invalid based on responses from the PowerSync service. The frequency of credential fetching has been reduced as a result of this work.
+
 ## 0.0.2-alpha.1
 
 - Introduce package. Support for Desktop .NET use cases.

--- a/PowerSync/PowerSync.Common/Client/PowerSyncDatabase.cs
+++ b/PowerSync/PowerSync.Common/Client/PowerSyncDatabase.cs
@@ -85,6 +85,7 @@ public interface IPowerSyncDatabase : IEventStream<PowerSyncDBEvent>
 
 public class PowerSyncDatabase : EventStream<PowerSyncDBEvent>, IPowerSyncDatabase
 {
+    private static readonly int FULL_SYNC_PRIORITY = 2147483647;
 
     public IDBAdapter Database;
     private Schema schema;
@@ -231,21 +232,34 @@ public class PowerSyncDatabase : EventStream<PowerSyncDBEvent>, IPowerSyncDataba
         }
     }
 
-    private record LastSyncedResult(string? synced_at);
+    private record LastSyncedResult(int? priority, string? last_synced_at);
 
     protected async Task UpdateHasSynced()
     {
-        var result = await Database.Get<LastSyncedResult>("SELECT powersync_last_synced_at() as synced_at");
+        var results = await Database.GetAll<LastSyncedResult>(
+            "SELECT priority, last_synced_at FROM ps_sync_state ORDER BY priority DESC"
+        );
 
-        var hasSynced = result.synced_at != null;
-        DateTime? syncedAt = result.synced_at != null ? DateTime.Parse(result.synced_at + "Z") : null;
+        DateTime? lastCompleteSync = null;
 
+        foreach (var result in results)
+        {
+            var parsedDate = DateTime.Parse(result.last_synced_at + "Z");
+
+            if (result.priority == FULL_SYNC_PRIORITY)
+            {
+                // This lowest-possible priority represents a complete sync.
+                lastCompleteSync = parsedDate;
+            }
+        }
+
+        var hasSynced = lastCompleteSync != null;
         if (hasSynced != CurrentStatus.HasSynced)
         {
             CurrentStatus = new SyncStatus(new SyncStatusOptions(CurrentStatus.Options)
             {
                 HasSynced = hasSynced,
-                LastSyncedAt = syncedAt
+                LastSyncedAt = lastCompleteSync,
             });
 
             Emit(new PowerSyncDBEvent { StatusChanged = CurrentStatus });

--- a/PowerSync/PowerSync.Common/Client/Sync/Stream/StreamingSyncImplementation.cs
+++ b/PowerSync/PowerSync.Common/Client/Sync/Stream/StreamingSyncImplementation.cs
@@ -539,11 +539,17 @@ public class StreamingSyncImplementation : EventStream<StreamingSyncImplementati
                         {
                             // Connection would be closed automatically right after this
                             logger.LogDebug("Token expiring; reconnect");
+                            Options.Remote.InvalidateCredentials();
 
                             // For a rare case where the backend connector does not update the token
                             // (uses the same one), this should have some delay.
                             //
                             await DelayRetry();
+                            return new StreamingSyncIterationResult { Retry = true };
+                        } else if (remainingSeconds < 30) {
+                            logger.LogDebug("Token will expire soon; reconnect");
+                            // Pre-emptively refresh the token
+                            Options.Remote.InvalidateCredentials();
                             return new StreamingSyncIterationResult { Retry = true };
                         }
                         TriggerCrudUpload();

--- a/PowerSync/PowerSync.Common/DB/Crud/SyncStatus.cs
+++ b/PowerSync/PowerSync.Common/DB/Crud/SyncStatus.cs
@@ -9,6 +9,20 @@ public class SyncDataFlowStatus
 
     [JsonProperty("uploading")]
     public bool Uploading { get; set; } = false;
+
+    /// <summary>
+    /// Error during downloading (including connecting).
+    /// Cleared on the next successful data download.
+    /// </summary>
+    [JsonProperty("downloadError")]
+    public Exception? DownloadError { get; set; } = null;
+
+    /// <summary>
+    /// Error during uploading.
+    /// Cleared on the next successful upload.
+    /// </summary>
+    [JsonProperty("uploadError")]
+    public Exception? UploadError { get; set; } = null;
 }
 
 public class SyncStatusOptions
@@ -73,7 +87,7 @@ public class SyncStatus(SyncStatusOptions options)
     public string GetMessage()
     {
         var dataFlow = DataFlowStatus;
-        return $"SyncStatus<connected: {Connected} connecting: {Connecting} lastSyncedAt: {LastSyncedAt} hasSynced: {HasSynced}. Downloading: {dataFlow.Downloading}. Uploading: {dataFlow.Uploading}>";
+        return $"SyncStatus<connected: {Connected} connecting: {Connecting} lastSyncedAt: {LastSyncedAt} hasSynced: {HasSynced}. Downloading: {dataFlow.Downloading}. Uploading: {dataFlow.Uploading}. UploadError: ${dataFlow.UploadError}, DownloadError?: ${dataFlow.DownloadError}>";
     }
 
     public string ToJSON()

--- a/Tools/Setup/Setup.cs
+++ b/Tools/Setup/Setup.cs
@@ -8,7 +8,7 @@ public class Setup
 {
     static async Task Main(string[] args)
     {
-        const string baseUrl = "https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v0.3.8";
+        const string baseUrl = "https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v0.3.14";
         string powersyncCorePath = Path.Combine(AppContext.BaseDirectory, "../../../../..", "PowerSync/PowerSync.Common/");
 
         var runtimeIdentifiers = new Dictionary<string, (string originalFile, string newFile)>


### PR DESCRIPTION
Working towards API parity with newly added features from other SDKs:

0. Updated core extension to latest release
1. Exposing upload/download errors in SyncStatus
2. Invalidating credentials when apt, instead of continuously calling fetchCredentials
3. Loading last synced time from core extension