### PR TITLE
Fix SQL Parameter Issues and Filename Typo in PowerSyncData.cs

### DIFF
--- a/demos/MAUITodo/Data/PowerSyncData.cs
+++ b/demos/MAUITodo/Data/PowerSyncData.cs
@@ -21,7 +21,7 @@ public class PowerSyncData
         });
         var logger = loggerFactory.CreateLogger("PowerSyncLogger");
 
-        var dbPath = Path.Combine(FileSystem.AppDataDirectory, "examplsee.db");
+        var dbPath = Path.Combine(FileSystem.AppDataDirectory, "example.db");
         var factory = new MAUISQLiteDBOpenFactory(new MDSQLiteOpenFactoryOptions()
         {
             DbFilename = dbPath
@@ -50,8 +50,8 @@ public class PowerSyncData
         else
         {
             await Db.Execute(
-                "INSERT INTO lists (id, created_at, name, owner_id, created_at) VALUES (uuid(), datetime(), ?, ?, ?)",
-                [list.Name, UserId, DateTime.UtcNow.ToString("o")]);
+                "INSERT INTO lists (id, created_at, name, owner_id) VALUES (uuid(), datetime(), ?, ?)",
+                [list.Name, UserId]);
         }
     }
 
@@ -82,14 +82,14 @@ public class PowerSyncData
         {
             await Db.Execute(
                 @"INSERT INTO todos 
-                  (id, list_id, description, created_at, completed, created_by, created_at)
-                  VALUES (uuid(), ?, ?, ?, ?, ?, datetime())",
+                  (id, list_id, description, created_at, completed, created_by, completed_at)
+                  VALUES (uuid(), ?, ?, datetime(), ?, ?, ?)",
                 [
                     item.ListId,
                     item.Description,
-                    item.CreatedAt,
                     item.Completed ? 1 : 0,
-                    UserId
+                    UserId,
+                    item.CompletedAt!,
                 ]);
         }
     }


### PR DESCRIPTION
## Fix SQL Parameter Issues and Filename Typo in PowerSyncData.cs

### Problem
- The `SaveListAsync` and `SaveItemAsync` methods had a few issues in their parameter specifications.
- There was a typo in the filename of the local SQLite database.

### Solution
- Fixed parameter issues in the `SaveListAsync` INSERT statement.
- Fixed parameter issues in the `SaveItemAsync` INSERT statement.
- Standardized use of SQLite `datetime()` function for consistency.
- Fixed typo in the SQLite database filename.

### Testing
- Verified that both INSERT queries execute without errors, and provide the proper data to the database.