### PR TITLE
fix: MAUI Extension loading 

### DIFF
--- a/.github/workflows/dev-packages.yml
+++ b/.github/workflows/dev-packages.yml
@@ -7,16 +7,21 @@ on: workflow_dispatch
 jobs:
   dev-release:
     name: Publish Dev Packages
-    runs-on: windows-latest
+    runs-on: macos-latest
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0' 
+          dotnet-version: '8.0'
+
+      - name: Install MAUI Workloads
+        run: dotnet workload restore
 
       - name: Download PowerSync extension
         run: dotnet run --project Tools/Setup    
@@ -37,7 +42,7 @@ jobs:
 
       - name: Run Push For Common
         continue-on-error: true
-        run: dotnet nuget push ${{ github.workspace }}\output\PowerSync.Common*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
+        run: dotnet nuget push ${{ github.workspace }}/output/PowerSync.Common*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
 
       - name: Extract MAUI Package Version from CHANGELOG.md
         id: extract_maui_version
@@ -46,10 +51,13 @@ jobs:
           MAUI_VERSION=$(awk '/^## [0-9]+\.[0-9]+\.[0-9]+-dev(\.[0-9]+)?$/ {print $2; exit}' PowerSync/PowerSync.Maui/CHANGELOG.md)
           echo "Detected Version: $MAUI_VERSION"
           echo "VERSION=$MAUI_VERSION" >> $GITHUB_ENV 
-          
+        
+      - name: Build MAUI Project
+        run: dotnet build PowerSync/PowerSync.Maui -c Release
+
       - name: Run Pack For MAUI
         run: dotnet pack PowerSync/PowerSync.Maui -c Release -o ${{ github.workspace }}/output
 
       - name: Run Push For MAUI
         continue-on-error: true
-        run: dotnet nuget push ${{ github.workspace }}\output\PowerSync.Maui*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}    
+        run: dotnet nuget push ${{ github.workspace }}/output/PowerSync.Maui*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,9 @@ jobs:
           MAUI_VERSION=$(awk '/^## [0-9]+\.[0-9]+\.[0-9]+/ {print $2; exit}' PowerSync/PowerSync.Maui/CHANGELOG.md)
           echo "Detected Version: $MAUI_VERSION"
           echo "VERSION=$MAUI_VERSION" >> $GITHUB_ENV
+          
+      - name: Build MAUI Project
+        run: dotnet build PowerSync/PowerSync.Maui -c Release
 
       - name: Run Pack For MAUI
         run: dotnet pack PowerSync/PowerSync.Maui -c Release -o ${{ github.workspace }}/output

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,17 +6,22 @@ on: workflow_dispatch
 jobs:
   release:
     name: Release
-    runs-on: windows-latest
+    runs-on: macos-latest
     if: github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0' 
+          dotnet-version: '8.0'
+
+      - name: Install MAUI Workloads
+        run: dotnet workload restore
 
       - name: Download PowerSync extension
         run: dotnet run --project Tools/Setup    
@@ -37,7 +42,7 @@ jobs:
 
       - name: Run Push for Common
         continue-on-error: true
-        run: dotnet nuget push ${{ github.workspace }}\output\PowerSync.Common*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
+        run: dotnet nuget push ${{ github.workspace }}/output/PowerSync.Common*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
 
       - name: Extract MAUI Package Version from CHANGELOG.md
         id: extract_maui_version
@@ -55,4 +60,4 @@ jobs:
 
       - name: Run Push For MAUI
         continue-on-error: true
-        run: dotnet nuget push ${{ github.workspace }}\output\PowerSync.Maui*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
+        run: dotnet nuget push ${{ github.workspace }}/output/PowerSync.Maui*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}

--- a/PowerSync/PowerSync.Common/CHANGELOG.md
+++ b/PowerSync/PowerSync.Common/CHANGELOG.md
@@ -1,5 +1,8 @@
 # PowerSync.Common Changelog
 
+## 0.0.4-dev.4
+- Fixing build issues related to MAUI targets not resolving on install.
+
 ## 0.0.3-alpha.1
 - Minor changes to accommodate PowerSync.MAUI package extension.
 

--- a/PowerSync/PowerSync.Common/CHANGELOG.md
+++ b/PowerSync/PowerSync.Common/CHANGELOG.md
@@ -1,7 +1,7 @@
 # PowerSync.Common Changelog
 
-## 0.0.4-dev.4
-- Fixing build issues related to MAUI targets not resolving on install.
+## 0.0.4-alpha.1
+- Fixed MAUI issues related to extension loading when installing package outside of the monorepo. 
 
 ## 0.0.3-alpha.1
 - Minor changes to accommodate PowerSync.MAUI package extension.

--- a/PowerSync/PowerSync.Common/PowerSync.Common.csproj
+++ b/PowerSync/PowerSync.Common/PowerSync.Common.csproj
@@ -30,17 +30,22 @@
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Include="PowerSync.Common.targets" Pack="true" PackagePath="build\" />
+    <None Include="PowerSync.Common.targets" Pack="true" PackagePath="buildTransitive\" />
+  </ItemGroup>
   
   <!-- Check allows us to skip for all MAUI targets-->
   <!-- For monorepo-->
-  <ItemGroup Condition="!$(TargetFramework.Contains('-'))">
+  <ItemGroup Condition="!$(TargetFramework.EndsWith('-android')) AND !$(TargetFramework.EndsWith('-ios'))">
     <Content Include="runtimes\**\*.*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 
   <!-- For releasing runtimes  -->
-  <ItemGroup Condition="!$(TargetFramework.Contains('-'))">
+  <ItemGroup Condition="!$(TargetFramework.EndsWith('-android')) AND !$(TargetFramework.EndsWith('-ios'))">
     <None Include="runtimes\**\*.*" Pack="true" PackagePath="runtimes\" />
   </ItemGroup>
   

--- a/PowerSync/PowerSync.Common/PowerSync.Common.targets
+++ b/PowerSync/PowerSync.Common/PowerSync.Common.targets
@@ -1,0 +1,7 @@
+<Project>
+  <Target Name="RemovePowerSyncNativeForAndroid" AfterTargets="ResolvePackageAssets" Condition="$(TargetFramework.Contains('android'))">
+    <ItemGroup>
+      <NativeCopyLocalItems Remove="@(NativeCopyLocalItems)" Condition="'%(NuGetPackageId)' == 'PowerSync.Common'" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/PowerSync/PowerSync.Maui/CHANGELOG.md
+++ b/PowerSync/PowerSync.Maui/CHANGELOG.md
@@ -1,5 +1,8 @@
 # PowerSync.Maui Changelog
 
+## 0.0.3-dev.1
+- Further resolution of iOS builds.
+
 ## 0.0.1-alpha.1
 
 - Introduce package. Support for iOS/Android use cases.

--- a/PowerSync/PowerSync.Maui/CHANGELOG.md
+++ b/PowerSync/PowerSync.Maui/CHANGELOG.md
@@ -1,7 +1,7 @@
 # PowerSync.Maui Changelog
 
-## 0.0.3-dev.1
-- Further resolution of iOS builds.
+## 0.0.2-alpha.1
+- Fixed issues related to extension loading when installing package outside of the monorepo.
 
 ## 0.0.1-alpha.1
 

--- a/PowerSync/PowerSync.Maui/PowerSync.Maui.csproj
+++ b/PowerSync/PowerSync.Maui/PowerSync.Maui.csproj
@@ -19,6 +19,9 @@
     <PackageIcon>icon.png</PackageIcon>
     <NoWarn>NU5100</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <IsBindingProject>true</IsBindingProject>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <IncludeBuildOutput>true</IncludeBuildOutput>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,26 +35,14 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
-  
-  <!-- For monorepo-->
-  <ItemGroup Condition="$(TargetFramework.Contains('-android'))">
-    <Content Include="Platforms\Android\**\*.*">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+
 
   <ItemGroup Condition="$(TargetFramework.Contains('-ios'))">
-    <Content Include="Platforms\iOS\NativeLibs\powersync-sqlite-core.xcframework\**\*.*">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+      <ObjcBindingApiDefinition Include="build\ApiDefinition.cs" />
 
-  <!-- For releasing runtimes  -->
-  <ItemGroup Condition="$(TargetFramework.Contains('-android'))">
-  <None Include="Platforms\Android\**\*.*" Pack="true" PackagePath="Platforms\Android" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.Contains('-ios'))">
-    <None Include="Platforms\iOS\NativeLibs\powersync-sqlite-core.xcframework\**\*.*" Pack="true" PackagePath="Platforms\iOS" />
+     <NativeReference Include="platforms\iOS\NativeLibs\powersync-sqlite-core.xcframework">
+     <Kind>Framework</Kind>
+      <SmartLink>False</SmartLink>
+     </NativeReference>
   </ItemGroup>
 </Project>

--- a/PowerSync/PowerSync.Maui/SQLite/MAUISQLiteAdapter.cs
+++ b/PowerSync/PowerSync.Maui/SQLite/MAUISQLiteAdapter.cs
@@ -19,7 +19,7 @@ public class MAUISQLiteAdapter : MDSQLiteAdapter
         db.EnableExtensions(true);
 
 #if IOS
-       LoadExtensionIOS(db);
+        LoadExtensionIOS(db);
 #elif ANDROID
         db.LoadExtension("libpowersync");
 #else
@@ -29,16 +29,21 @@ public class MAUISQLiteAdapter : MDSQLiteAdapter
 
     private void LoadExtensionIOS(SqliteConnection db)
     {
-        #if IOS
-        var bundlePath = Foundation.NSBundle.MainBundle.BundlePath;
+#if IOS
+        var bundlePath = Foundation.NSBundle.FromIdentifier("co.powersync.sqlitecore")?.BundlePath;
+        if (bundlePath == null)
+        {
+            throw new Exception("Could not find PowerSync SQLite extension bundle path");
+        }
+
         var filePath =
-            Path.Combine(bundlePath, "Frameworks", "powersync-sqlite-core.framework", "powersync-sqlite-core");
-        
+            Path.Combine(bundlePath, "powersync-sqlite-core");
+
         using var loadExtension = db.CreateCommand();
         loadExtension.CommandText = "SELECT load_extension(@path, @entryPoint)";
         loadExtension.Parameters.AddWithValue("@path", filePath);
         loadExtension.Parameters.AddWithValue("@entryPoint", "sqlite3_powersync_init");
         loadExtension.ExecuteNonQuery();
-        #endif
+#endif
     }
 }

--- a/PowerSync/PowerSync.Maui/build/ApiDefinition.cs
+++ b/PowerSync/PowerSync.Maui/build/ApiDefinition.cs
@@ -1,4 +1,4 @@
-namespace YourNamespace
+namespace PowerSync.Maui.build
 {
     // Empty API definition - allows xcframework to be included without managed bindings
 }

--- a/PowerSync/PowerSync.Maui/build/ApiDefinition.cs
+++ b/PowerSync/PowerSync.Maui/build/ApiDefinition.cs
@@ -1,0 +1,4 @@
+namespace YourNamespace
+{
+    // Empty API definition - allows xcframework to be included without managed bindings
+}

--- a/demos/MAUITodo/MAUITodo.csproj
+++ b/demos/MAUITodo/MAUITodo.csproj
@@ -3,9 +3,9 @@
 	<PropertyGroup>
 	    <ApplicationId>com.companyname.todo</ApplicationId>
 
-		<TargetFrameworks>net8.0-android;net8.0-ios</TargetFrameworks>
+		<TargetFrameworks>net8.0-android</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
-
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net8.0-ios</TargetFrameworks>
 		
 		<OutputType>Exe</OutputType>
 		<RootNamespace>MAUITodo</RootNamespace>
@@ -34,6 +34,13 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>
 	</PropertyGroup>
+	
+	<!-- Potentially only needed for net8.0-ios: https://github.com/microsoft/appcenter-sdk-dotnet/issues/1755#issuecomment-2373256340 -->
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-ios|AnyCPU'">
+		<RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
+		<ForceSimulatorX64ArchitectureInIDE>true</ForceSimulatorX64ArchitectureInIDE>
+	</PropertyGroup>
+	
 	<ItemGroup>
 		<!-- App Icon -->
 		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />

--- a/demos/MAUITodo/README.md
+++ b/demos/MAUITodo/README.md
@@ -51,3 +51,10 @@ dotnet build -t:Run -f:net8.0-android -p:_DeviceName=emulator-5554
 ```sh
 dotnet run -f net8.0-windows10.0.19041.0
 ```
+
+## Android on Windows
+You may need to overwrite the [backend and PowerSync URLs](./Data/NodeConnector.cs) when running an Android emulator on Windows.
+```
+BackendUrl = "http://10.0.2.2:6060";
+PowerSyncUrl = "http://10.0.2.2:8080";
+```


### PR DESCRIPTION
## Description
We originally introduced the MAUI package. The aim was to add extension loading for iOS, Android, and Windows targets. During a recent PoC of the Windows target, I discovered that installing the MAUI package externally (from Nuget via a `PackageReference`) instead of internally (from the Monorepo via `ProjectReference`) doesn’t correctly unpack the rust core extension. 

## Problem/Solutions:
- Windows MAUI not working at all (incorrectly configured Common `.csproj` ignore rule).
    - **Solution**: Fixed the `.csproj` ignore rules that were excluding the runtimes for the `net8.0-windows` target.
- Externally installing `PowerSync.Maui` targeting iOS not loading the extension on MacOS. 
    - **Solution**: Changed the MAUI to be a binding project, that includes the XCFramework as a NativeReference. You can only currently build iOS binding projects on Mac, updated the workflows accordingly. Also using the correct BundlePath utility.
    - **Solution**: Added a special runtimeIdentifier when targeting `net8.0-ios` in our demo.
- Externally installing `PowerSync.Maui` and running an Android emulator on Windows resolving the incorrect extension (`Linux-x64` instead of `x86_64`).
    - **Solution**: Added a build targets file to Common that explicitly removes the  Linux extension in favour of the extension from MAUI when building for Android.
    
## Future Work
A lot of these workarounds and issues are caused by `PowerSync.Common` being responsible for loading the PC platforms. This logic can be simplified if we extract that responsibility to a dedicated package. Common+MAUI for the Android case wouldn't have been affected by the last issue.