### PR TITLE
Check AppContext.BaseDirectory for `powersync.dll`

### DIFF
--- a/PowerSync/PowerSync.Common/Utils/PowerSyncPathResolver.cs
+++ b/PowerSync/PowerSync.Common/Utils/PowerSyncPathResolver.cs
@@ -8,7 +8,7 @@ public static class PowerSyncPathResolver
     {
         string fileName = GetFileNameForPlatform();
 
-        // Check the flattened path first since some technologies (eg. .NET 4.8 Framework) flatten libraries into the root folder.
+        // Check the flattened path first since some technologies (eg. .NET Framework 4.8) flatten libraries into the root folder.
         // Checking this path first also makes debugging easier, since one can easily change the resolved DLL.
         string flattenedPath = Path.Combine(packagePath, fileName);
         if (File.Exists(flattenedPath)) return flattenedPath;


### PR DESCRIPTION
Fixes #14 by checking the application's base directory for the PowerSync SQLite3 extension library.

Currently, `PowerSync.Common` only checks the "portable deployment" path (`<approot>/runtimes/<rid>/native/powersync.{dylib,so,dll}`) for the extension. However, there a number of technologies (Windows Application Packaging projects, .NET Framework 4.8, etc.) which don't follow this convention and instead place all shared libraries in the same directory as the executable. This PR adds a check to see if it can find `powersync.{dylib,so,dll}` in the root folder, and if so, loads that library instead of searching for the `runtimes/<rid>/native` one.

I considered allowing the user to configure the path to check for `powersync.dll`, but decided against it since practically all .NET apps use either the flattened deployment or the structured `runtimes/<rid>/native` deployment already.