### PR TITLE
Prepare 0.1.1 release

### DIFF
--- a/PowerSync/PowerSync.Common/CHANGELOG.md
+++ b/PowerSync/PowerSync.Common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PowerSync.Common Changelog
 
-## 0.1.1 (unreleased)
+## 0.1.1
 
 - Support Windows ARM.
 - Update the PowerSync SQLite core extension to 0.4.12.

--- a/PowerSync/PowerSync.Maui/CHANGELOG.md
+++ b/PowerSync/PowerSync.Maui/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PowerSync.Maui Changelog
 
+## 0.1.1
+
+- Upstream PowerSync.Common version bump (See Powersync.Common changelog 0.1.1 for more information)
+
 ## 0.1.0
 
 - Beta release.


### PR DESCRIPTION
This prepares a patch release to add aarch64 Windows support.

I couldn't find release instructions anywhere in the repository, but from a quick look at `release.yml` it should just involve updating changelogs, merging to main and triggering that workflow? Please let me know if I'm missing a step.