### PR TITLE
Add `net9.0-android` and `net9.0-ios` as supported targets

### DIFF
--- a/PowerSync/PowerSync.Common/CHANGELOG.md
+++ b/PowerSync/PowerSync.Common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PowerSync.Common Changelog
 
-## 0.1.2
+## 0.1.2-dev.1
 
 - Fix `net9.0-android` and `net9.0-ios` not being in TargetFrameworks.
 

--- a/PowerSync/PowerSync.Common/CHANGELOG.md
+++ b/PowerSync/PowerSync.Common/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PowerSync.Common Changelog
 
+## 0.1.2
+
+- Fix `net9.0-android` and `net9.0-ios` not being in TargetFrameworks.
+
 ## 0.1.1
 
 - Support Windows ARM.

--- a/PowerSync/PowerSync.Common/PowerSync.Common.csproj
+++ b/PowerSync/PowerSync.Common/PowerSync.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0;net8.0-ios;net8.0-android</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0;net8.0-ios;net8.0-android;net9.0-ios;net9.0-android</TargetFrameworks>
     <LangVersion>12</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/PowerSync/PowerSync.Maui/CHANGELOG.md
+++ b/PowerSync/PowerSync.Maui/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PowerSync.Maui Changelog
 
-## 0.1.2
+## 0.1.2-dev.1
 
 - Fix `net9.0-android` and `net9.0-ios` not being in TargetFrameworks.
 

--- a/PowerSync/PowerSync.Maui/CHANGELOG.md
+++ b/PowerSync/PowerSync.Maui/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PowerSync.Maui Changelog
 
+## 0.1.2
+
+- Fix `net9.0-android` and `net9.0-ios` not being in TargetFrameworks.
+
 ## 0.1.1
 
 - Upstream PowerSync.Common version bump (See Powersync.Common changelog 0.1.1 for more information)

--- a/PowerSync/PowerSync.Maui/PowerSync.Maui.csproj
+++ b/PowerSync/PowerSync.Maui/PowerSync.Maui.csproj
@@ -20,7 +20,6 @@
     <NoWarn>NU5100</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <IsBindingProject>true</IsBindingProject>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeBuildOutput>true</IncludeBuildOutput>
   </PropertyGroup>
 

--- a/PowerSync/PowerSync.Maui/PowerSync.Maui.csproj
+++ b/PowerSync/PowerSync.Maui/PowerSync.Maui.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0;net8.0-ios;net8.0-android</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0;net8.0-ios;net8.0-android;net9.0-ios;net9.0-android</TargetFrameworks>
     <LangVersion>12</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\PowerSync.Common\PowerSync.Common.csproj" />
+    <ProjectReference Include="..\PowerSync.Common\PowerSync.Common.csproj" SetTargetFramework="TargetFramework=$(TargetFramework)" />
   </ItemGroup>
   
   <ItemGroup>

--- a/PowerSync/PowerSync.Maui/PowerSync.Maui.csproj
+++ b/PowerSync/PowerSync.Maui/PowerSync.Maui.csproj
@@ -44,4 +44,15 @@
       <SmartLink>False</SmartLink>
      </NativeReference>
   </ItemGroup>
+
+  <!-- Prevent e_sqlite3.a from being frozen into the binding manifest. It is provided by
+       SQLitePCLRaw.lib.e_sqlite3.ios with separate device/simulator variants, selected at
+       consuming-project build time via buildTransitive targets. Capturing it here would bake
+       in the device-only variant and break simulator builds in consuming projects. -->
+  <Target Name="_RemoveE_Sqlite3FromBindingManifest" BeforeTargets="_SanitizeNativeReferences" Condition="'$(IsBindingProject)' == 'true'">
+    <ItemGroup>
+      <NativeReference Remove="@(NativeReference)" Condition="'%(Filename)' == 'e_sqlite3'" />
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
We have `net9.0` as a supported target framework, but not `net9.0-android` or `net9.0-ios`. This breaks how we resolve the loading of the powersync-sqlite-extension, which relies on the IOS or ANDROID tags being present in order to determine which library to bundle and where to look for it at runtime. This PR adds those targets (plus a few other changes to make creating local `.nupkg` files more consistent.)

Thanks to @wizardness for bringing this to our attention in #58. :)

NB: Merging on hold until this is confirmed to actually fix the issue.