### PR TITLE
0.1.2

### DIFF
--- a/PowerSync/PowerSync.Common/CHANGELOG.md
+++ b/PowerSync/PowerSync.Common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PowerSync.Common Changelog
 
-## 0.1.2-dev.1
+## 0.1.2
 
 - Fix `net9.0-android` and `net9.0-ios` not being in TargetFrameworks.
 

--- a/PowerSync/PowerSync.Maui/CHANGELOG.md
+++ b/PowerSync/PowerSync.Maui/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PowerSync.Maui Changelog
 
-## 0.1.2-dev.1
+## 0.1.2
 
 - Fix `net9.0-android` and `net9.0-ios` not being in TargetFrameworks.
 


### PR DESCRIPTION
Note: The demos still target .NET 8.0, this will likely change if/when MacCatalyst support is added (I checked the demos using .NET 9.0 and they do work, I just haven't committed the changes in this PR.)