### PR TITLE
Mac catalyst support and .NET 9.0 support in demos

### DIFF
--- a/PowerSync/PowerSync.Common/CHANGELOG.md
+++ b/PowerSync/PowerSync.Common/CHANGELOG.md
@@ -1,8 +1,10 @@
 # PowerSync.Common Changelog
 
-## 0.1.2-dev.1
+## 0.1.2
 
-- Fix `net9.0-android` and `net9.0-ios` not being in TargetFrameworks.
+- Add support for MacCatalyst.
+- Add support for .NET 9.0. Supported targets now also include `net9.0`, `net9.0-android`, `net9.0-ios`, and `net9.0-maccatalyst`.
+- Update the PowerSync SQLite core extension to 0.4.13.
 
 ## 0.1.1
 

--- a/PowerSync/PowerSync.Common/PowerSync.Common.csproj
+++ b/PowerSync/PowerSync.Common/PowerSync.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0;net8.0-ios;net8.0-android;net9.0-ios;net9.0-android</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0;net8.0-ios;net8.0-android;net8.0-maccatalyst;net9.0-ios;net9.0-android;net9.0-maccatalyst</TargetFrameworks>
     <LangVersion>12</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -45,14 +45,14 @@
   
   <!-- Check allows us to skip for all MAUI targets-->
   <!-- For monorepo-->
-  <ItemGroup Condition="!$(TargetFramework.EndsWith('-android')) AND !$(TargetFramework.EndsWith('-ios'))">
+  <ItemGroup Condition="!$(TargetFramework.EndsWith('-android')) AND !$(TargetFramework.EndsWith('-ios')) AND !$(TargetFramework.EndsWith('-maccatalyst'))">
     <Content Include="runtimes\**\*.*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 
   <!-- For releasing runtimes  -->
-  <ItemGroup Condition="!$(TargetFramework.EndsWith('-android')) AND !$(TargetFramework.EndsWith('-ios'))">
+  <ItemGroup Condition="!$(TargetFramework.EndsWith('-android')) AND !$(TargetFramework.EndsWith('-ios')) AND !$(TargetFramework.EndsWith('-maccatalyst'))">
     <None Include="runtimes\**\*.*" Pack="true" PackagePath="runtimes\" />
   </ItemGroup>
   

--- a/PowerSync/PowerSync.Maui/CHANGELOG.md
+++ b/PowerSync/PowerSync.Maui/CHANGELOG.md
@@ -1,8 +1,10 @@
 # PowerSync.Maui Changelog
 
-## 0.1.2-dev.1
+## 0.1.2
 
-- Fix `net9.0-android` and `net9.0-ios` not being in TargetFrameworks.
+- Add support for MacCatalyst.
+- Add support for .NET 9.0. Supported targets now also include `net9.0`, `net9.0-android`, `net9.0-ios`, and `net9.0-maccatalyst`.
+- Upstream PowerSync.Common version bump (See Powersync.Common changelog 0.1.2 for more information)
 
 ## 0.1.1
 

--- a/PowerSync/PowerSync.Maui/PowerSync.Maui.csproj
+++ b/PowerSync/PowerSync.Maui/PowerSync.Maui.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0;net8.0-ios;net8.0-android;net9.0-ios;net9.0-android</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0;net8.0-ios;net8.0-android;net8.0-maccatalyst;net9.0-ios;net9.0-android;net9.0-maccatalyst</TargetFrameworks>
     <LangVersion>12</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -43,6 +43,15 @@
      <Kind>Framework</Kind>
       <SmartLink>False</SmartLink>
      </NativeReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework.Contains('-maccatalyst'))">
+      <ObjcBindingApiDefinition Include="build\ApiDefinition.cs" />
+
+      <NativeReference Include="Platforms\MacCatalyst\NativeLibs\powersync-sqlite-core.xcframework">
+        <Kind>Framework</Kind>
+        <SmartLink>False</SmartLink>
+      </NativeReference>
   </ItemGroup>
 
   <!-- Prevent e_sqlite3.a from being frozen into the binding manifest. It is provided by

--- a/PowerSync/PowerSync.Maui/SQLite/MAUISQLiteAdapter.cs
+++ b/PowerSync/PowerSync.Maui/SQLite/MAUISQLiteAdapter.cs
@@ -4,8 +4,8 @@ using Microsoft.Data.Sqlite;
 
 using PowerSync.Common.MDSQLite;
 
-// iOS specific imports
-#if IOS
+// iOS/MacCatalyst specific imports
+#if IOS || MACCATALYST
 using Foundation;
 #endif
 
@@ -19,8 +19,8 @@ public class MAUISQLiteAdapter : MDSQLiteAdapter
     {
         db.EnableExtensions(true);
 
-#if IOS
-        LoadExtensionIOS(db);
+#if IOS || MACCATALYST
+        LoadExtensionApple(db);
 #elif ANDROID
         db.LoadExtension("libpowersync");
 #else
@@ -28,9 +28,9 @@ public class MAUISQLiteAdapter : MDSQLiteAdapter
 #endif
     }
 
-    private void LoadExtensionIOS(SqliteConnection db)
+    private void LoadExtensionApple(SqliteConnection db)
     {
-#if IOS
+#if IOS || MACCATALYST
         var bundlePath = Foundation.NSBundle.FromIdentifier("co.powersync.sqlitecore")?.BundlePath;
         if (bundlePath == null)
         {
@@ -48,3 +48,4 @@ public class MAUISQLiteAdapter : MDSQLiteAdapter
 #endif
     }
 }
+

--- a/Tools/Setup/Setup.cs
+++ b/Tools/Setup/Setup.cs
@@ -10,7 +10,7 @@ using System.IO.Compression;
 /// </summary>
 public class PowerSyncSetup
 {
-    private const string VERSION = "0.4.12";
+    private const string VERSION = "0.4.13";
 
     private const string GITHUB_BASE_URL = $"https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v{VERSION}";
     private const string MAVEN_BASE_URL = $"https://repo1.maven.org/maven2/com/powersync/powersync-sqlite-core/{VERSION}";
@@ -199,7 +199,7 @@ public class PowerSyncSetup
             if (Directory.Exists(extractedPath))
                 Directory.Delete(extractedPath, recursive: true);
 
-            ZipFile.ExtractToDirectory(downloadPath, nativeDir);
+            ExtractZipPreservingSymlinks(downloadPath, nativeDir);
             File.Delete(downloadPath);
 
             Console.WriteLine($"✓ Extracted {config.ArchiveFileName} → {config.ExtractedName}");
@@ -207,6 +207,29 @@ public class PowerSyncSetup
         catch (Exception ex)
         {
             Console.Error.WriteLine($"✗ Failed to process archive: {ex.Message}");
+        }
+    }
+
+    private static void ExtractZipPreservingSymlinks(string zipPath, string destDir)
+    {
+        // ZipFile.ExtractToDirectory does not preserve symlinks, which breaks
+        // macOS/Catalyst .xcframework bundles. Use `unzip` on Unix instead.
+        if (!OperatingSystem.IsWindows())
+        {
+            var proc = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "unzip",
+                ArgumentList = { "-o", zipPath, "-d", destDir },
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            })!;
+            proc.WaitForExit();
+            if (proc.ExitCode != 0)
+                throw new Exception($"unzip exited with code {proc.ExitCode}: {proc.StandardError.ReadToEnd()}");
+        }
+        else
+        {
+            ZipFile.ExtractToDirectory(zipPath, destDir);
         }
     }
 

--- a/Tools/Setup/Setup.cs
+++ b/Tools/Setup/Setup.cs
@@ -31,6 +31,7 @@ public class PowerSyncSetup
             await SetupDesktop();
             await SetupMauiIos();
             await SetupMauiAndroid();
+            await SetupMauiMacCatalyst();
         }
         finally
         {
@@ -125,6 +126,19 @@ public class PowerSyncSetup
         {
             Console.Error.WriteLine($"✗ Failed to setup Android: {ex.Message}");
         }
+    }
+
+    public async Task SetupMauiMacCatalyst()
+    {
+        Console.WriteLine("Setting up MAUI MacCatalyst libraries...");
+
+        var nativeDir = Path.Combine(_basePath, "PowerSync.Maui", "Platforms", "MacCatalyst", "NativeLibs");
+        var config = new ArchiveConfig(
+            "powersync-sqlite-core.xcframework.zip",
+            "powersync-sqlite-core.xcframework"
+        );
+
+        await ProcessArchiveDownload(nativeDir, config, GITHUB_BASE_URL);
     }
 
     private void ExtractAarNativeLibraries(string aarPath, string nativeDir)

--- a/demos/CommandLine/CommandLine.csproj
+++ b/demos/CommandLine/CommandLine.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Version>0.0.1</Version>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <LangVersion>12</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/demos/MAUITodo/Data/NodeConnector.cs
+++ b/demos/MAUITodo/Data/NodeConnector.cs
@@ -25,8 +25,14 @@ public class NodeConnector : IPowerSyncBackendConnector
         // Load or generate User ID
         UserId = LoadOrGenerateUserId();
 
+        // Android emulator uses 10.0.2.2 to access host-ran processes
+#if ANDROID
+        BackendUrl = "http://10.0.2.2:6060";
+        PowerSyncUrl = "http://10.0.2.2:8080";
+#else
         BackendUrl = "http://localhost:6060";
         PowerSyncUrl = "http://localhost:8080";
+#endif
 
         clientId = null;
     }

--- a/demos/MAUITodo/MAUITodo.csproj
+++ b/demos/MAUITodo/MAUITodo.csproj
@@ -5,7 +5,7 @@
 
 		<TargetFrameworks>net8.0-android</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net8.0-ios</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
 		
 		<OutputType>Exe</OutputType>
 		<RootNamespace>MAUITodo</RootNamespace>
@@ -32,6 +32,7 @@
 	    <MauiVersion>8.0.90</MauiVersion>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>

--- a/demos/MAUITodo/MAUITodo.csproj
+++ b/demos/MAUITodo/MAUITodo.csproj
@@ -3,9 +3,9 @@
 	<PropertyGroup>
 	    <ApplicationId>com.companyname.todo</ApplicationId>
 
-		<TargetFrameworks>net8.0-android</TargetFrameworks>
+		<TargetFrameworks>net8.0-android;net9.0-android</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net8.0-ios;net8.0-maccatalyst;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
 		
 		<OutputType>Exe</OutputType>
 		<RootNamespace>MAUITodo</RootNamespace>
@@ -31,8 +31,8 @@
 	
 	    <MauiVersion>8.0.90</MauiVersion>
 
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>

--- a/demos/MAUITodo/Platforms/MacCatalyst/Entitlements.plist
+++ b/demos/MAUITodo/Platforms/MacCatalyst/Entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+</dict>
+</plist>

--- a/demos/MAUITodo/Platforms/MacCatalyst/Info.plist
+++ b/demos/MAUITodo/Platforms/MacCatalyst/Info.plist
@@ -2,17 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
-	</dict>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>
@@ -37,5 +26,7 @@
 	</array>
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/appicon.appiconset</string>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/demos/MAUITodo/Platforms/MacCatalyst/Info.plist
+++ b/demos/MAUITodo/Platforms/MacCatalyst/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>localhost</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/demos/MAUITodo/README.md
+++ b/demos/MAUITodo/README.md
@@ -48,3 +48,8 @@ Specifying an Android emulator
 dotnet build -t:Run -f:net8.0-android -p:_DeviceName=emulator-5554
 ```
 
+### MacCatalyst
+
+```sh
+dotnet build -t:Run -f:net8.0-maccatalyst
+```

--- a/demos/MAUITodo/README.md
+++ b/demos/MAUITodo/README.md
@@ -11,7 +11,7 @@ Changes made to the backend's source DB or to the self-hosted web UI will be syn
 In the repo root, run the following to download the PowerSync extension:
 
 ```bash
-dotnet run --project Tools/Setup    
+dotnet run --project Tools/Setup
 ```
 
 Then switch into the demo's directory:
@@ -31,6 +31,7 @@ dotnet build -t:Run -f:net8.0-ios
 ```
 
 Specifyng an iOS simulator
+
 ```sh
 dotnet build -t:Run -f:net8.0-ios -p:_DeviceName=:v2:udid=B1CA156A-56FC-4C3C-B35D-4BC349111FDF
 ```
@@ -42,19 +43,8 @@ dotnet build -t:Run -f:net8.0-android
 ```
 
 Specifying an Android emulator
+
 ```sh
 dotnet build -t:Run -f:net8.0-android -p:_DeviceName=emulator-5554
 ```
 
-### Windows
-
-```sh
-dotnet run -f net8.0-windows10.0.19041.0
-```
-
-## Android on Windows
-You may need to overwrite the [backend and PowerSync URLs](./Data/NodeConnector.cs) when running an Android emulator on Windows.
-```
-BackendUrl = "http://10.0.2.2:6060";
-PowerSyncUrl = "http://10.0.2.2:8080";
-```

--- a/demos/MAUITodo/Views/ListsPage.xaml
+++ b/demos/MAUITodo/Views/ListsPage.xaml
@@ -5,7 +5,7 @@
              Title="Todo Lists">
     <ContentPage.ToolbarItems>
         <ToolbarItem x:Name="WifiStatusItem"
-                     Order="Primary" 
+                     Order="Primary"
                      Priority="0"/>
     </ContentPage.ToolbarItems>
 


### PR DESCRIPTION
Ref: https://github.com/powersync-ja/powersync-dotnet/issues/56

Adds support for Mac Catalyst and bumps demo versions to support .NET 9.0.

**What that entails:**
- Adds `net9.0` and `net9.0-[ios,android,maccatalyst]` targets to relevant projects.
- Bumps minimum version for MAUITodo iOS to 15.0 (minimum for `net9.0`).
- Small modifications to MAUITodo demo to support MacCatalyst.
- Updates `Tools/Setup.cs` script to download MacCatalyst-supporting `xcframework`.
- Bump `powersync-sqlite-core` version to 0.4.13.

**Notes:**
- ~At the time of writing, the MacCatalyst build in the [SQLite extension repo](https://github.com/powersync-ja/powersync-sqlite-core) is not fully functional (automaterialization of symlinks that should stay symlinks); this will be resolved before the PR is merged.~
   - Turns out the bug was with Archive Utility not preserving symlinks. Incredibly strange. Anyways, switching to `unzip` seems to have solved the issue.