### PR TITLE
Support loading custom SQLite extensions

### DIFF
--- a/PowerSync/PowerSync.Common/CHANGELOG.md
+++ b/PowerSync/PowerSync.Common/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add support for .NET 9.0. Supported targets now also include `net9.0`, `net9.0-android`, `net9.0-ios`, and `net9.0-maccatalyst`.
 - Update the PowerSync SQLite core extension to 0.4.13.
 - Add support for offline-first file attachments via `AttachmentQueue`. See `Attachments/README.md`.
+- Add support for loading custom SQLite extensions via `MDSqliteOptions.Extensions`.
 
 ## 0.1.1
 

--- a/PowerSync/PowerSync.Common/CHANGELOG.md
+++ b/PowerSync/PowerSync.Common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PowerSync.Common Changelog
 
-## 0.1.3 (unreleased)
+## 0.1.3-dev.1
 
 - Add support for loading custom SQLite extensions via `MDSQLiteOptions.Extensions`.
 

--- a/PowerSync/PowerSync.Common/CHANGELOG.md
+++ b/PowerSync/PowerSync.Common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PowerSync.Common Changelog
 
-## 0.1.3
+## 0.1.3 (unreleased)
 
 - Add support for loading custom SQLite extensions via `MDSQLiteOptions.Extensions`.
 

--- a/PowerSync/PowerSync.Common/CHANGELOG.md
+++ b/PowerSync/PowerSync.Common/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add support for .NET 9.0. Supported targets now also include `net9.0`, `net9.0-android`, `net9.0-ios`, and `net9.0-maccatalyst`.
 - Update the PowerSync SQLite core extension to 0.4.13.
 - Add support for offline-first file attachments via `AttachmentQueue`. See `Attachments/README.md`.
-- Add support for loading custom SQLite extensions via `MDSqliteOptions.Extensions`.
+- Add support for loading custom SQLite extensions via `MDSQLiteOptions.Extensions`.
 
 ## 0.1.1
 

--- a/PowerSync/PowerSync.Common/CHANGELOG.md
+++ b/PowerSync/PowerSync.Common/CHANGELOG.md
@@ -1,12 +1,15 @@
 # PowerSync.Common Changelog
 
+## 0.1.3
+
+- Add support for loading custom SQLite extensions via `MDSQLiteOptions.Extensions`.
+
 ## 0.1.2
 
 - Add support for MacCatalyst.
 - Add support for .NET 9.0. Supported targets now also include `net9.0`, `net9.0-android`, `net9.0-ios`, and `net9.0-maccatalyst`.
 - Update the PowerSync SQLite core extension to 0.4.13.
 - Add support for offline-first file attachments via `AttachmentQueue`. See `Attachments/README.md`.
-- Add support for loading custom SQLite extensions via `MDSQLiteOptions.Extensions`.
 
 ## 0.1.1
 

--- a/PowerSync/PowerSync.Common/MDSQLite/MDSQLiteAdapter.cs
+++ b/PowerSync/PowerSync.Common/MDSQLite/MDSQLiteAdapter.cs
@@ -125,7 +125,7 @@ public class MDSQLiteAdapter : IDBAdapter
     protected async Task<MDSQLiteConnection> OpenConnection(string dbFilename)
     {
         var db = OpenDatabase(dbFilename);
-        LoadExtension(db);
+        LoadExtensions(db);
 
         var connection = new MDSQLiteConnection(new MDSQLiteConnectionOptions(db));
         await connection.Execute("SELECT powersync_init()");
@@ -141,11 +141,13 @@ public class MDSQLiteAdapter : IDBAdapter
         return connection;
     }
 
-    protected virtual void LoadExtension(SqliteConnection db)
+    protected virtual void LoadExtensions(SqliteConnection db)
     {
-        string extensionPath = PowerSyncPathResolver.GetNativeLibraryPath(AppContext.BaseDirectory);
         db.EnableExtensions(true);
-        db.LoadExtension(extensionPath, "sqlite3_powersync_init");
+        foreach (var extension in resolvedOptions.Extensions)
+        {
+            db.LoadExtension(extension.Path, extension.EntryPoint);
+        }
     }
 
     public async Task Close()
@@ -367,7 +369,7 @@ class MDSQLiteConnectionPool
     private async Task<MDSQLiteConnection> OpenConnection(string dbFilename)
     {
         var db = OpenDatabase(dbFilename);
-        LoadExtension(db);
+        LoadExtensions(db);
 
         var connection = new MDSQLiteConnection(new MDSQLiteConnectionOptions(db));
         await connection.Execute("SELECT powersync_init()");
@@ -383,11 +385,13 @@ class MDSQLiteConnectionPool
         return connection;
     }
 
-    private void LoadExtension(SqliteConnection db)
+    private void LoadExtensions(SqliteConnection db)
     {
-        string extensionPath = PowerSyncPathResolver.GetNativeLibraryPath(AppContext.BaseDirectory);
         db.EnableExtensions(true);
-        db.LoadExtension(extensionPath, "sqlite3_powersync_init");
+        foreach (var extension in _options.Extensions)
+        {
+            db.LoadExtension(extension.Path, extension.EntryPoint);
+        }
     }
 
     public async Task Close()

--- a/PowerSync/PowerSync.Common/MDSQLite/MDSQLiteAdapter.cs
+++ b/PowerSync/PowerSync.Common/MDSQLite/MDSQLiteAdapter.cs
@@ -129,7 +129,22 @@ public class MDSQLiteAdapter : IDBAdapter
         LoadExtensions(db);
 
         var connection = new MDSQLiteConnection(new MDSQLiteConnectionOptions(db));
-        await connection.Execute("SELECT powersync_init()");
+        try
+        {
+            await connection.Execute("SELECT powersync_init()");
+        }
+        catch (SqliteException ex)
+        {
+            // SQLite will throw a very unhelpful "SQLite Error 1: 'The specified
+            // module could not be found.'" error if uncaught.
+            throw new SqliteException(
+                "Failed to initialize PowerSync: powersync_init() is not registered. " +
+                "Ensure the PowerSync core SQLite extension is loaded. Either set " +
+                "MDSQLiteOptions.LoadPowerSyncExtension to true (default), or supply " +
+                "a PowerSync-compatible extension via MDSQLiteOptions.Extensions.",
+                ex.SqliteErrorCode,
+                ex.SqliteExtendedErrorCode);
+        }
 
         return connection;
     }

--- a/PowerSync/PowerSync.Common/MDSQLite/MDSQLiteAdapter.cs
+++ b/PowerSync/PowerSync.Common/MDSQLite/MDSQLiteAdapter.cs
@@ -60,6 +60,7 @@ public class MDSQLiteAdapter : IDBAdapter
             LockTimeoutMs = options?.LockTimeoutMs ?? defaults.LockTimeoutMs,
             EncryptionKey = options?.EncryptionKey ?? defaults.EncryptionKey,
             Extensions = options?.Extensions ?? defaults.Extensions,
+            LoadPowerSyncExtension = options?.LoadPowerSyncExtension ?? defaults.LoadPowerSyncExtension,
             ReadPoolSize = options?.ReadPoolSize ?? defaults.ReadPoolSize,
         };
     }
@@ -105,7 +106,7 @@ public class MDSQLiteAdapter : IDBAdapter
             }
             return readConnection;
         };
-        readPool = new MDSQLiteConnectionPool(resolvedOptions, readConnectionFactory);
+        readPool = new MDSQLiteConnectionPool(resolvedOptions.ReadPoolSize, readConnectionFactory);
         await readPool.Init();
 
         // Register TablesUpdated listener
@@ -144,10 +145,25 @@ public class MDSQLiteAdapter : IDBAdapter
     protected virtual void LoadExtensions(SqliteConnection db)
     {
         db.EnableExtensions(true);
+        if (resolvedOptions.LoadPowerSyncExtension)
+        {
+            LoadDefaultPowerSyncExtension(db);
+        }
         foreach (var extension in resolvedOptions.Extensions)
         {
             db.LoadExtension(extension.Path, extension.EntryPoint);
         }
+    }
+
+    /// <summary>
+    /// Loads the bundled PowerSync core SQLite extension. Override on
+    /// platform-specific adapters (e.g. MAUI iOS/Android) where the native library
+    /// lives outside the desktop runtime path.
+    /// </summary>
+    protected virtual void LoadDefaultPowerSyncExtension(SqliteConnection db)
+    {
+        var path = PowerSyncPathResolver.GetNativeLibraryPath(AppContext.BaseDirectory);
+        db.LoadExtension(path, "sqlite3_powersync_init");
     }
 
     public async Task Close()
@@ -303,18 +319,16 @@ public class MDSQLiteAdapter : IDBAdapter
 
 class MDSQLiteConnectionPool
 {
-    private readonly RequiredMDSQLiteOptions _options;
     private readonly Channel<MDSQLiteConnection> _channel;
     private readonly int _poolSize;
     private readonly Func<Task<MDSQLiteConnection>> _connectionFactory;
 
     private readonly Task _initialized;
 
-    public MDSQLiteConnectionPool(RequiredMDSQLiteOptions options, Func<Task<MDSQLiteConnection>> connectionFactory)
+    public MDSQLiteConnectionPool(int poolSize, Func<Task<MDSQLiteConnection>> connectionFactory)
     {
-        _options = options;
-        _channel = Channel.CreateBounded<MDSQLiteConnection>(options.ReadPoolSize);
-        _poolSize = options.ReadPoolSize;
+        _channel = Channel.CreateBounded<MDSQLiteConnection>(poolSize);
+        _poolSize = poolSize;
         _connectionFactory = connectionFactory;
         _initialized = Initialize();
     }
@@ -363,34 +377,6 @@ class MDSQLiteConnectionPool
             {
                 _channel.Writer.TryWrite(conn);
             }
-        }
-    }
-
-    private async Task<MDSQLiteConnection> OpenConnection(string dbFilename)
-    {
-        var db = OpenDatabase(dbFilename);
-        LoadExtensions(db);
-
-        var connection = new MDSQLiteConnection(new MDSQLiteConnectionOptions(db));
-        await connection.Execute("SELECT powersync_init()");
-
-        return connection;
-    }
-
-    private static SqliteConnection OpenDatabase(string dbFilename)
-    {
-        string connectionString = $"Data Source={dbFilename};Pooling=False;";
-        var connection = new SqliteConnection(connectionString);
-        connection.Open();
-        return connection;
-    }
-
-    private void LoadExtensions(SqliteConnection db)
-    {
-        db.EnableExtensions(true);
-        foreach (var extension in _options.Extensions)
-        {
-            db.LoadExtension(extension.Path, extension.EntryPoint);
         }
     }
 

--- a/PowerSync/PowerSync.Common/MDSQLite/MDSQLiteOptions.cs
+++ b/PowerSync/PowerSync.Common/MDSQLite/MDSQLiteOptions.cs
@@ -1,5 +1,7 @@
 namespace PowerSync.Common.MDSQLite;
 
+using PowerSync.Common.Utils;
+
 public sealed class TemporaryStorageOption
 {
     public static readonly TemporaryStorageOption MEMORY = new("memory");
@@ -55,9 +57,26 @@ public sealed class SqliteSynchronous
 
 public class SqliteExtension
 {
+    public static SqliteExtension DEFAULT_POWERSYNC_EXTENSION = new()
+    {
+        Path = TryResolveDefaultPowerSyncExtensionPath(),
+        EntryPoint = "sqlite3_powersync_init",
+    };
+    public static SqliteExtension[] DEFAULT_POWERSYNC_EXTENSIONS = [DEFAULT_POWERSYNC_EXTENSION];
+
     public string Path { get; set; } = string.Empty;
     public string? EntryPoint { get; set; }
+
+    // PowerSyncPathResolver only knows about desktop RIDs and throws on iOS/Android.
+    // Swallow that here so this static field can be referenced safely on mobile —
+    // platform-aware adapters (e.g. MAUI) intercept the sentinel before reading Path.
+    private static string TryResolveDefaultPowerSyncExtensionPath()
+    {
+        try { return PowerSyncPathResolver.GetNativeLibraryPath(AppContext.BaseDirectory); }
+        catch (PlatformNotSupportedException) { return string.Empty; }
+    }
 }
+
 
 public class MDSQLiteOptions
 {
@@ -99,7 +118,9 @@ public class MDSQLiteOptions
     public int? CacheSizeKb { get; set; }
 
     /// <summary>
-    /// Load extensions using the path and entryPoint.
+    /// Load SQLite extensions using the path and entryPoint. Defaults to
+    /// SqliteExtension.DEFAULT_POWERSYNC_EXTENSIONS. Remember to re-add
+    /// the DEFAULT_POWERSYNC_EXTENSION if modifying the list of extensions.
     /// </summary>
     public SqliteExtension[]? Extensions { get; set; }
 
@@ -120,7 +141,7 @@ public class RequiredMDSQLiteOptions : MDSQLiteOptions
         TemporaryStorage = TemporaryStorageOption.MEMORY,
         LockTimeoutMs = 30000,
         EncryptionKey = null,
-        Extensions = [],
+        Extensions = SqliteExtension.DEFAULT_POWERSYNC_EXTENSIONS,
         ReadPoolSize = 5,
     };
 

--- a/PowerSync/PowerSync.Common/MDSQLite/MDSQLiteOptions.cs
+++ b/PowerSync/PowerSync.Common/MDSQLite/MDSQLiteOptions.cs
@@ -1,7 +1,5 @@
 namespace PowerSync.Common.MDSQLite;
 
-using PowerSync.Common.Utils;
-
 public sealed class TemporaryStorageOption
 {
     public static readonly TemporaryStorageOption MEMORY = new("memory");
@@ -57,26 +55,9 @@ public sealed class SqliteSynchronous
 
 public class SqliteExtension
 {
-    public static SqliteExtension DEFAULT_POWERSYNC_EXTENSION = new()
-    {
-        Path = TryResolveDefaultPowerSyncExtensionPath(),
-        EntryPoint = "sqlite3_powersync_init",
-    };
-    public static SqliteExtension[] DEFAULT_POWERSYNC_EXTENSIONS = [DEFAULT_POWERSYNC_EXTENSION];
-
     public string Path { get; set; } = string.Empty;
     public string? EntryPoint { get; set; }
-
-    // PowerSyncPathResolver only knows about desktop RIDs and throws on iOS/Android.
-    // Swallow that here so this static field can be referenced safely on mobile —
-    // platform-aware adapters (e.g. MAUI) intercept the sentinel before reading Path.
-    private static string TryResolveDefaultPowerSyncExtensionPath()
-    {
-        try { return PowerSyncPathResolver.GetNativeLibraryPath(AppContext.BaseDirectory); }
-        catch (PlatformNotSupportedException) { return string.Empty; }
-    }
 }
-
 
 public class MDSQLiteOptions
 {
@@ -118,11 +99,22 @@ public class MDSQLiteOptions
     public int? CacheSizeKb { get; set; }
 
     /// <summary>
-    /// Load SQLite extensions using the path and entryPoint. Defaults to
-    /// SqliteExtension.DEFAULT_POWERSYNC_EXTENSIONS. Remember to re-add
-    /// the DEFAULT_POWERSYNC_EXTENSION if modifying the list of extensions.
+    /// Additional SQLite extensions to load on every connection, in order. Defaults
+    /// to an empty list. The bundled PowerSync core extension is loaded separately
+    /// and controlled by <see cref="LoadPowerSyncExtension"/> — do not include it
+    /// here.
     /// </summary>
     public SqliteExtension[]? Extensions { get; set; }
+
+    /// <summary>
+    /// Whether to load the bundled PowerSync core SQLite extension on every
+    /// connection. Defaults to true and should remain true for normal use — the
+    /// rest of the library relies on the SQL functions and virtual tables it
+    /// registers (e.g. <c>powersync_init()</c>). Set to false only if you are
+    /// supplying an equivalent PowerSync-compatible extension via
+    /// <see cref="Extensions"/>.
+    /// </summary>
+    public bool? LoadPowerSyncExtension { get; set; }
 
     /// <summary>
     /// The number of MDSQLiteConnection objects to create for the read pool.
@@ -141,7 +133,8 @@ public class RequiredMDSQLiteOptions : MDSQLiteOptions
         TemporaryStorage = TemporaryStorageOption.MEMORY,
         LockTimeoutMs = 30000,
         EncryptionKey = null,
-        Extensions = SqliteExtension.DEFAULT_POWERSYNC_EXTENSIONS,
+        Extensions = [],
+        LoadPowerSyncExtension = true,
         ReadPoolSize = 5,
     };
 
@@ -160,6 +153,8 @@ public class RequiredMDSQLiteOptions : MDSQLiteOptions
     public new int CacheSizeKb { get; set; }
 
     public new SqliteExtension[] Extensions { get; set; } = null!;
+
+    public new bool LoadPowerSyncExtension { get; set; }
 
     public new int ReadPoolSize { get; set; }
 }

--- a/PowerSync/PowerSync.Maui/CHANGELOG.md
+++ b/PowerSync/PowerSync.Maui/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PowerSync.Maui Changelog
 
-## 0.1.3 (unreleased)
+## 0.1.3-dev.1
 
 - Upstream PowerSync.Common version bump (See Powersync.Common changelog 0.1.3 for more information)
 

--- a/PowerSync/PowerSync.Maui/CHANGELOG.md
+++ b/PowerSync/PowerSync.Maui/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PowerSync.Maui Changelog
 
+## 0.1.3
+
+- Upstream PowerSync.Common version bump (See Powersync.Common changelog 0.1.2 for more information)
+
 ## 0.1.2
 
 - Add support for MacCatalyst.

--- a/PowerSync/PowerSync.Maui/CHANGELOG.md
+++ b/PowerSync/PowerSync.Maui/CHANGELOG.md
@@ -1,8 +1,8 @@
 # PowerSync.Maui Changelog
 
-## 0.1.3
+## 0.1.3 (unreleased)
 
-- Upstream PowerSync.Common version bump (See Powersync.Common changelog 0.1.2 for more information)
+- Upstream PowerSync.Common version bump (See Powersync.Common changelog 0.1.3 for more information)
 
 ## 0.1.2
 

--- a/PowerSync/PowerSync.Maui/SQLite/MAUISQLiteAdapter.cs
+++ b/PowerSync/PowerSync.Maui/SQLite/MAUISQLiteAdapter.cs
@@ -15,20 +15,49 @@ public class MAUISQLiteAdapter : MDSQLiteAdapter
     {
     }
 
-    protected override void LoadExtension(SqliteConnection db)
+    protected override void LoadExtensions(SqliteConnection db)
     {
         db.EnableExtensions(true);
 
+        // The default PowerSync extension's path is resolved for desktop runtimes and
+        // does not apply on iOS/MacCatalyst/Android, where the native library lives
+        // in a platform-specific location. If the user didn't supply any extensions,
+        // load the platform-correct default. Otherwise honor their list — but still
+        // intercept the DEFAULT_POWERSYNC_EXTENSION sentinel so consumers can mix
+        // the bundled PowerSync extension with their own custom extensions.
+        var userExtensions = options.SqliteOptions?.Extensions;
+        if (userExtensions == null)
+        {
+            LoadDefaultPowerSyncExtension(db);
+            return;
+        }
+
+        foreach (var extension in userExtensions)
+        {
+            if (ReferenceEquals(extension, SqliteExtension.DEFAULT_POWERSYNC_EXTENSION))
+            {
+                LoadDefaultPowerSyncExtension(db);
+            }
+            else
+            {
+                db.LoadExtension(extension.Path, extension.EntryPoint);
+            }
+        }
+    }
+
+    private static void LoadDefaultPowerSyncExtension(SqliteConnection db)
+    {
 #if IOS || MACCATALYST
         LoadExtensionApple(db);
 #elif ANDROID
         db.LoadExtension("libpowersync");
 #else
-        base.LoadExtension(db);
+        var defaultExtension = SqliteExtension.DEFAULT_POWERSYNC_EXTENSION;
+        db.LoadExtension(defaultExtension.Path, defaultExtension.EntryPoint);
 #endif
     }
 
-    private void LoadExtensionApple(SqliteConnection db)
+    private static void LoadExtensionApple(SqliteConnection db)
     {
 #if IOS || MACCATALYST
         var bundlePath = Foundation.NSBundle.FromIdentifier("co.powersync.sqlitecore")?.BundlePath;

--- a/PowerSync/PowerSync.Maui/SQLite/MAUISQLiteAdapter.cs
+++ b/PowerSync/PowerSync.Maui/SQLite/MAUISQLiteAdapter.cs
@@ -15,45 +15,20 @@ public class MAUISQLiteAdapter : MDSQLiteAdapter
     {
     }
 
-    protected override void LoadExtensions(SqliteConnection db)
-    {
-        db.EnableExtensions(true);
-
-        // The default PowerSync extension's path is resolved for desktop runtimes and
-        // does not apply on iOS/MacCatalyst/Android, where the native library lives
-        // in a platform-specific location. If the user didn't supply any extensions,
-        // load the platform-correct default. Otherwise honor their list — but still
-        // intercept the DEFAULT_POWERSYNC_EXTENSION sentinel so consumers can mix
-        // the bundled PowerSync extension with their own custom extensions.
-        var userExtensions = options.SqliteOptions?.Extensions;
-        if (userExtensions == null)
-        {
-            LoadDefaultPowerSyncExtension(db);
-            return;
-        }
-
-        foreach (var extension in userExtensions)
-        {
-            if (ReferenceEquals(extension, SqliteExtension.DEFAULT_POWERSYNC_EXTENSION))
-            {
-                LoadDefaultPowerSyncExtension(db);
-            }
-            else
-            {
-                db.LoadExtension(extension.Path, extension.EntryPoint);
-            }
-        }
-    }
-
-    private static void LoadDefaultPowerSyncExtension(SqliteConnection db)
+    // The bundled PowerSync extension lives in a platform-specific location on
+    // iOS/MacCatalyst/Android — the desktop runtime path used by the base class
+    // does not resolve to it. Override only the PowerSync-extension load hook;
+    // user-supplied custom extensions still flow through MDSQLiteAdapter.LoadExtensions
+    // unchanged, so consumers can freely combine the bundled extension (via the
+    // LoadPowerSyncExtension flag) with their own.
+    protected override void LoadDefaultPowerSyncExtension(SqliteConnection db)
     {
 #if IOS || MACCATALYST
         LoadExtensionApple(db);
 #elif ANDROID
         db.LoadExtension("libpowersync");
 #else
-        var defaultExtension = SqliteExtension.DEFAULT_POWERSYNC_EXTENSION;
-        db.LoadExtension(defaultExtension.Path, defaultExtension.EntryPoint);
+        base.LoadDefaultPowerSyncExtension(db);
 #endif
     }
 

--- a/Tests/PowerSync/PowerSync.Common.Tests/EventStreamTests.cs
+++ b/Tests/PowerSync/PowerSync.Common.Tests/EventStreamTests.cs
@@ -217,24 +217,25 @@ public class EventStreamTests
 
         var cts = new CancellationTokenSource();
         var listener = stream.ListenAsync(cts.Token);
+        var tcs = new TaskCompletionSource<bool>();
         var sem = new SemaphoreSlim(0);
         int eventCount = 0;
 
         _ = Task.Run(async () =>
         {
-            sem.Release();
+            tcs.SetResult(true);
             await foreach (var evt in listener)
             {
                 eventCount++;
                 sem.Release();
             }
         }, cts.Token);
-        Assert.True(await sem.WaitAsync(100));
+        await tcs.Task;
 
         Assert.True(manager.Deregister<string>());
 
         Assert.False(manager.TryEmit("invalid"));
-        Assert.False(await sem.WaitAsync(100));
+        Assert.False(await sem.WaitAsync(500));
 
         // Cleanup
         cts.Cancel();

--- a/Tests/PowerSync/PowerSync.Common.Tests/MDSQLite/MDSQLiteAdapterTests.cs
+++ b/Tests/PowerSync/PowerSync.Common.Tests/MDSQLite/MDSQLiteAdapterTests.cs
@@ -1,0 +1,89 @@
+namespace PowerSync.Common.Tests.MDSQLite;
+
+using Microsoft.Data.Sqlite;
+
+using PowerSync.Common.Client;
+using PowerSync.Common.MDSQLite;
+using PowerSync.Common.Tests.Utils;
+
+/// <summary>
+/// dotnet test -v n --framework net8.0 --filter "MDSQLiteAdapterTests"
+/// </summary>
+[Collection("MDSQLiteAdapterTests")]
+public class MDSQLiteAdapterTests
+{
+    private class AssetResult
+    {
+        public string id { get; set; } = "";
+        public string description { get; set; } = "";
+        public string? make { get; set; }
+    }
+
+    private static PowerSyncDatabase BuildDbWithExtensions(string dbFilename, SqliteExtension[] extensions)
+    {
+        return new PowerSyncDatabase(new PowerSyncDatabaseOptions
+        {
+            Database = new MDSQLiteDBOpenFactory(new MDSQLiteOpenFactoryOptions
+            {
+                DbFilename = dbFilename,
+                SqliteOptions = new MDSQLiteOptions { Extensions = extensions },
+            }),
+            Schema = TestSchema.AppSchema,
+        });
+    }
+
+    private static string CopyDefaultExtensionToTempPath()
+    {
+        var sourcePath = SqliteExtension.DEFAULT_POWERSYNC_EXTENSION.Path;
+        var tempPath = Path.Combine(
+            Path.GetTempPath(),
+            $"powersync-ext-copy-{Guid.NewGuid():N}{Path.GetExtension(sourcePath)}"
+        );
+        File.Copy(sourcePath, tempPath, overwrite: true);
+        return tempPath;
+    }
+
+    [Fact]
+    public async Task EmptyExtensionsArrayDoesNotLoadPowerSync()
+    {
+        var name = $"MDSQLiteAdapter-ext-empty-{Guid.NewGuid():N}.db";
+        var db = BuildDbWithExtensions(name, []);
+
+        try
+        {
+            // Without the PowerSync extension, `powersync_init()` is not a registered function.
+            await Assert.ThrowsAsync<SqliteException>(async () => await db.Init());
+        }
+        finally
+        {
+            try { await db.Close(); } catch { /* expected — init failed */ }
+            DatabaseUtils.CleanDb(name);
+        }
+    }
+
+    [Fact]
+    public async Task LoadsCustomPowerSyncExtensionFromOverriddenPath()
+    {
+        var name = $"MDSQLiteAdapter-ext-custom-{Guid.NewGuid():N}.db";
+        var customPath = CopyDefaultExtensionToTempPath();
+        var db = BuildDbWithExtensions(name, [
+            new SqliteExtension { Path = customPath, EntryPoint = "sqlite3_powersync_init" },
+        ]);
+
+        try
+        {
+            await db.Init();
+
+            var id = await TestUtils.InsertRandomAsset(db);
+            var rows = await db.GetAll<AssetResult>("SELECT id, description, make FROM assets");
+            Assert.Single(rows);
+            Assert.Equal(id, rows[0].id);
+        }
+        finally
+        {
+            await db.Close();
+            DatabaseUtils.CleanDb(name);
+            try { File.Delete(customPath); } catch { /* best-effort cleanup */ }
+        }
+    }
+}

--- a/Tests/PowerSync/PowerSync.Common.Tests/MDSQLite/MDSQLiteAdapterTests.cs
+++ b/Tests/PowerSync/PowerSync.Common.Tests/MDSQLite/MDSQLiteAdapterTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Data.Sqlite;
 using PowerSync.Common.Client;
 using PowerSync.Common.MDSQLite;
 using PowerSync.Common.Tests.Utils;
+using PowerSync.Common.Utils;
 
 /// <summary>
 /// dotnet test -v n --framework net8.0 --filter "MDSQLiteAdapterTests"
@@ -19,35 +20,23 @@ public class MDSQLiteAdapterTests
         public string? make { get; set; }
     }
 
-    private static PowerSyncDatabase BuildDbWithExtensions(string dbFilename, SqliteExtension[] extensions)
+    [Fact]
+    public async Task DisablingCoreExtensionPreventsPowerSyncFromLoading()
     {
-        return new PowerSyncDatabase(new PowerSyncDatabaseOptions
+        var dbName = $"MDSQLiteAdapter-{Guid.NewGuid():N}.db";
+        var db = new PowerSyncDatabase(new PowerSyncDatabaseOptions
         {
             Database = new MDSQLiteDBOpenFactory(new MDSQLiteOpenFactoryOptions
             {
-                DbFilename = dbFilename,
-                SqliteOptions = new MDSQLiteOptions { Extensions = extensions },
+                DbFilename = dbName,
+                SqliteOptions = new MDSQLiteOptions
+                {
+                    LoadPowerSyncExtension = false,
+                    Extensions = [],
+                },
             }),
             Schema = TestSchema.AppSchema,
         });
-    }
-
-    private static string CopyDefaultExtensionToTempPath()
-    {
-        var sourcePath = SqliteExtension.DEFAULT_POWERSYNC_EXTENSION.Path;
-        var tempPath = Path.Combine(
-            Path.GetTempPath(),
-            $"powersync-ext-copy-{Guid.NewGuid():N}{Path.GetExtension(sourcePath)}"
-        );
-        File.Copy(sourcePath, tempPath, overwrite: true);
-        return tempPath;
-    }
-
-    [Fact]
-    public async Task EmptyExtensionsArrayDoesNotLoadPowerSync()
-    {
-        var name = $"MDSQLiteAdapter-ext-empty-{Guid.NewGuid():N}.db";
-        var db = BuildDbWithExtensions(name, []);
 
         try
         {
@@ -57,18 +46,36 @@ public class MDSQLiteAdapterTests
         finally
         {
             try { await db.Close(); } catch { /* expected — init failed */ }
-            DatabaseUtils.CleanDb(name);
+            DatabaseUtils.CleanDb(dbName);
         }
     }
 
     [Fact]
     public async Task LoadsCustomPowerSyncExtensionFromOverriddenPath()
     {
-        var name = $"MDSQLiteAdapter-ext-custom-{Guid.NewGuid():N}.db";
-        var customPath = CopyDefaultExtensionToTempPath();
-        var db = BuildDbWithExtensions(name, [
-            new SqliteExtension { Path = customPath, EntryPoint = "sqlite3_powersync_init" },
-        ]);
+        var dbName = $"MDSQLiteAdapter-{Guid.NewGuid():N}.db";
+        var sourcePath = PowerSyncPathResolver.GetNativeLibraryPath(AppContext.BaseDirectory);
+        var customPath = Path.Combine(
+            Path.GetTempPath(),
+            $"powersync-ext-copy-{Guid.NewGuid():N}{Path.GetExtension(sourcePath)}"
+        );
+        File.Copy(sourcePath, customPath, overwrite: true);
+
+        var db = new PowerSyncDatabase(new PowerSyncDatabaseOptions
+        {
+            Database = new MDSQLiteDBOpenFactory(new MDSQLiteOpenFactoryOptions
+            {
+                DbFilename = dbName,
+                SqliteOptions = new MDSQLiteOptions
+                {
+                    LoadPowerSyncExtension = false,
+                    Extensions = [
+                        new SqliteExtension { Path = customPath, EntryPoint = "sqlite3_powersync_init" },
+                    ],
+                },
+            }),
+            Schema = TestSchema.AppSchema,
+        });
 
         try
         {
@@ -82,7 +89,7 @@ public class MDSQLiteAdapterTests
         finally
         {
             await db.Close();
-            DatabaseUtils.CleanDb(name);
+            DatabaseUtils.CleanDb(dbName);
             try { File.Delete(customPath); } catch { /* best-effort cleanup */ }
         }
     }


### PR DESCRIPTION
Wires up the existing `MDSQLiteOptions.Extensions` setting, which allows for loading custom sqlite3 extensions on PowerSync-managed connections. Also adds a flag `MDSQLiteOptions.LoadPowerSyncExtension` that changes if the default core extension is loaded or not, which is useful for platforms which place the `powersync` library in a nonstandard location (eg. issue #71).