### PR TITLE
Add attachments to MAUITodo demo

### DIFF
--- a/demos/MAUITodo/Attachments/NodeRemoteStorageAdapter.cs
+++ b/demos/MAUITodo/Attachments/NodeRemoteStorageAdapter.cs
@@ -1,0 +1,39 @@
+using PowerSync.Common.Attachments;
+
+namespace MAUITodo.Attachments;
+
+public class NodeRemoteStorageAdapter : IRemoteStorageAdapter
+{
+    private readonly HttpClient _client;
+    private readonly string _backendUrl;
+
+    public NodeRemoteStorageAdapter(HttpClient client, string backendUrl)
+    {
+        _client = client;
+        _backendUrl = backendUrl;
+    }
+
+    public async Task UploadFileAsync(Stream fileData, Attachment attachment)
+    {
+        var content = new StreamContent(fileData);
+        content.Headers.ContentType = new(attachment.MediaType ?? "application/octet-stream");
+        var response = await _client.PutAsync($"{_backendUrl}/api/attachments/{attachment.Id}", content);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task<Stream> DownloadFileAsync(Attachment attachment)
+    {
+        var response = await _client.GetAsync($"{_backendUrl}/api/attachments/{attachment.Id}");
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            return Stream.Null;
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStreamAsync();
+    }
+
+    public async Task DeleteFileAsync(Attachment attachment)
+    {
+        var response = await _client.DeleteAsync($"{_backendUrl}/api/attachments/{attachment.Id}");
+        if (response.StatusCode != System.Net.HttpStatusCode.NotFound)
+            response.EnsureSuccessStatusCode();
+    }
+}

--- a/demos/MAUITodo/Data/AppSchema.cs
+++ b/demos/MAUITodo/Data/AppSchema.cs
@@ -1,11 +1,13 @@
 using MAUITodo.Models;
 
+using PowerSync.Common.Attachments;
 using PowerSync.Common.DB.Schema;
 
 class AppSchema
 {
     public static Table Todos = new Table(typeof(TodoItem));
     public static Table Lists = new Table(typeof(TodoList));
+    public static Table Attachments = new Table(typeof(Attachment));
 
-    public static Schema PowerSyncSchema = new Schema(Todos, Lists);
+    public static Schema PowerSyncSchema = new Schema(Todos, Lists, Attachments);
 }

--- a/demos/MAUITodo/Data/PowerSyncData.cs
+++ b/demos/MAUITodo/Data/PowerSyncData.cs
@@ -1,7 +1,11 @@
-﻿using MAUITodo.Models;
+using System.Runtime.CompilerServices;
+
+using MAUITodo.Attachments;
+using MAUITodo.Models;
 
 using Microsoft.Extensions.Logging;
 
+using PowerSync.Common.Attachments;
 using PowerSync.Common.Client;
 using PowerSync.Common.MDSQLite;
 using PowerSync.Maui.SQLite;
@@ -11,6 +15,7 @@ namespace MAUITodo.Data;
 public class PowerSyncData
 {
     public PowerSyncDatabase Db;
+    public AttachmentQueue PhotoAttachmentQueue { get; }
     private string UserId { get; }
 
     public PowerSyncData()
@@ -39,7 +44,37 @@ public class PowerSyncData
         UserId = nodeConnector.UserId;
 
         Db.Connect(nodeConnector);
+
+        var attachmentsDir = Path.Combine(FileSystem.AppDataDirectory, "attachments");
+        var localStorage = new FileManagerLocalStorage(attachmentsDir);
+        var remoteStorage = new NodeRemoteStorageAdapter(new HttpClient(), nodeConnector.BackendUrl);
+
+        PhotoAttachmentQueue = new AttachmentQueue(new AttachmentQueueOptions
+        {
+            Db = Db,
+            LocalStorage = localStorage,
+            RemoteStorage = remoteStorage,
+            WatchAttachments = ct => WatchTodoPhotos(Db, ct),
+        });
+
+        _ = Task.Run(() => PhotoAttachmentQueue.StartSyncAsync());
     }
+
+    private static async IAsyncEnumerable<WatchedAttachmentItem[]> WatchTodoPhotos(
+        PowerSyncDatabase db,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var stream = db.Watch<PhotoIdResult>(
+            "SELECT photo_id FROM todos WHERE photo_id IS NOT NULL",
+            [],
+            new SQLWatchOptions { TriggerImmediately = true, Signal = ct });
+        await foreach (var rows in stream.WithCancellation(ct))
+        {
+            yield return [.. rows.Select(r => new WatchedAttachmentItem(r.photo_id, fileExtension: "jpg"))];
+        }
+    }
+
+    private record PhotoIdResult(string photo_id);
 
     public async Task SaveListAsync(TodoList list)
     {
@@ -59,10 +94,23 @@ public class PowerSyncData
 
     public async Task DeleteListAsync(TodoList list)
     {
-        var listId = list.ID;
-        // First delete all todo items in this list
-        await Db.Execute("DELETE FROM todos WHERE list_id = ?", [listId]);
-        await Db.Execute("DELETE FROM lists WHERE id = ?", [listId]);
+        await Db.WriteTransaction(async tx =>
+        {
+            // Prevent attachments from being orphaned when their owning todo is deleted;
+            // `has_synced = 0` prevents the attachments from becoming archived instead of deleted.
+            //
+            // It would be nice to be able to do this sort of bulk-delete using the attachments API directly.
+            await tx.Execute(
+                @"UPDATE attachments
+                  SET state = ?, has_synced = 0
+                  WHERE id IN (SELECT photo_id FROM todos WHERE list_id = ? AND photo_id IS NOT NULL)",
+                [(int)AttachmentState.QueuedDelete, list.ID]);
+            await tx.Execute("DELETE FROM todos WHERE list_id = ?", [list.ID]);
+            await tx.Execute("DELETE FROM lists WHERE id = ?", [list.ID]);
+        });
+
+        // Force the attachments queue to acknowledge the changes immediately
+        PhotoAttachmentQueue.TriggerSync();
     }
 
     public async Task SaveItemAsync(TodoItem item)
@@ -70,13 +118,13 @@ public class PowerSyncData
         if (item.ID != "")
         {
             await Db.Execute(
-                @"UPDATE todos 
+                @"UPDATE todos
                   SET description = ?, completed = ?, completed_at = ?, completed_by = ?
                   WHERE id = ?",
                 [
                     item.Description,
-                    item.Completed ? 1 : 0,
-                    item.CompletedAt!,
+                    item.Completed,
+                    item.CompletedAt,
                     item.Completed ? UserId : null,
                     item.ID
                 ]);
@@ -84,7 +132,7 @@ public class PowerSyncData
         else
         {
             await Db.Execute(
-                @"INSERT INTO todos 
+                @"INSERT INTO todos
                   (id, list_id, description, created_at, created_by, completed, completed_at, completed_by)
                   VALUES (uuid(), ?, ?, datetime(), ?, ?, ?, ?)",
                 [
@@ -98,12 +146,30 @@ public class PowerSyncData
         }
     }
 
+    public async Task SaveTodoPhotoAsync(string todoId, Stream photoData)
+    {
+        await PhotoAttachmentQueue.SaveFileAsync(
+            data: photoData,
+            fileExtension: "jpg",
+            mediaType: "image/jpeg",
+            updateHook: (tx, attachment) =>
+                tx.Execute("UPDATE todos SET photo_id = ? WHERE id = ?", [attachment.Id, todoId]));
+    }
+
+    public async Task RemoveTodoPhotoAsync(string todoId, string photoId)
+    {
+        await PhotoAttachmentQueue.DeleteFileAsync(
+            id: photoId,
+            updateHook: (tx, _) =>
+                tx.Execute("UPDATE todos SET photo_id = NULL WHERE id = ?", [todoId]));
+    }
+
     public async Task SaveTodoCompletedAsync(string todoId, bool completed)
     {
         if (completed)
         {
             await Db.Execute(
-                @"UPDATE todos 
+                @"UPDATE todos
                   SET completed = 1, completed_at = datetime(), completed_by = ?
                   WHERE id = ?",
                 [
@@ -114,7 +180,7 @@ public class PowerSyncData
         else
         {
             await Db.Execute(
-                @"UPDATE todos 
+                @"UPDATE todos
                   SET completed = 0, completed_at = NULL, completed_by = NULL
                   WHERE id = ?",
                 [
@@ -125,6 +191,26 @@ public class PowerSyncData
 
     public async Task DeleteItemAsync(TodoItem item)
     {
-        await Db.Execute("DELETE FROM todos WHERE id = ?", [item.ID]);
+        if (item.PhotoId != null)
+        {
+            // DeleteFileAsync can fail if a `todos` row is synced with a photo_id, but the 
+            // corresponding `attachments` row/item hasn't been created yet. Fallback to regular
+            // `DELETE FROM todos`.
+            try
+            {
+                await PhotoAttachmentQueue.DeleteFileAsync(
+                    id: item.PhotoId,
+                    updateHook: (tx, _) =>
+                        tx.Execute("DELETE FROM todos WHERE id = ?", [item.ID]));
+            }
+            catch
+            {
+                await Db.Execute("DELETE FROM todos WHERE id = ?", [item.ID]);
+            }
+        }
+        else
+        {
+            await Db.Execute("DELETE FROM todos WHERE id = ?", [item.ID]);
+        }
     }
 }

--- a/demos/MAUITodo/Models/TodoItem.cs
+++ b/demos/MAUITodo/Models/TodoItem.cs
@@ -3,7 +3,7 @@
 using PowerSync.Common.DB.Schema.Attributes;
 
 [
-    Table("todos"),
+    Table("todos", IgnoreEmptyUpdates = true),
     Index("list", ["list_id"])
 ]
 public class TodoItem
@@ -31,4 +31,23 @@ public class TodoItem
 
     [Column("completed")]
     public bool Completed { get; set; }
+
+    [Column("photo_id")]
+    public string? PhotoId { get; set; }
+
+    // Display-only properties. [Ignored] keeps them out of the PowerSync schema (they are not
+    // real columns on the `todos` table), while [Column] still lets Dapper hydrate PhotoLocalUri
+    // from the `photo_local_uri` alias produced by the attachments LEFT JOIN in the watch query.
+    [Ignored]
+    [Column("photo_local_uri")]
+    public string? PhotoLocalUri { get; set; }
+
+    [Ignored]
+    public bool HasNoPhoto => PhotoId == null;
+
+    [Ignored]
+    public bool IsDownloading => PhotoId != null && PhotoLocalUri == null;
+
+    [Ignored]
+    public bool IsPhotoReady => PhotoLocalUri != null;
 }

--- a/demos/MAUITodo/Models/TodoList.cs
+++ b/demos/MAUITodo/Models/TodoList.cs
@@ -2,7 +2,7 @@ namespace MAUITodo.Models;
 
 using PowerSync.Common.DB.Schema.Attributes;
 
-[Table("lists")]
+[Table("lists", IgnoreEmptyUpdates = true)]
 public class TodoList
 {
     [Column("id")]

--- a/demos/MAUITodo/Platforms/Android/AndroidManifest.xml
+++ b/demos/MAUITodo/Platforms/Android/AndroidManifest.xml
@@ -3,4 +3,12 @@
 	<application android:usesCleartextTraffic="true" android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
+	<uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+	<uses-permission android:name="android.permission.CAMERA" />
+	<queries>
+		<intent>
+			<action android:name="android.media.action.IMAGE_CAPTURE" />
+		</intent>
+	</queries>
 </manifest>

--- a/demos/MAUITodo/Platforms/MacCatalyst/Info.plist
+++ b/demos/MAUITodo/Platforms/MacCatalyst/Info.plist
@@ -28,5 +28,9 @@
 	<string>Assets.xcassets/appicon.appiconset</string>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Used to attach photos to todo items.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Used to take photos to attach to todo items.</string>
 </dict>
 </plist>

--- a/demos/MAUITodo/Platforms/iOS/Info.plist
+++ b/demos/MAUITodo/Platforms/iOS/Info.plist
@@ -28,5 +28,9 @@
 	</array>
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/appicon.appiconset</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Used to attach photos to todo items.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Used to take photos to attach to todo items.</string>
 </dict>
 </plist>

--- a/demos/MAUITodo/Views/ListsPage.xaml.cs
+++ b/demos/MAUITodo/Views/ListsPage.xaml.cs
@@ -8,6 +8,7 @@ namespace MAUITodo.Views;
 public partial class ListsPage
 {
     private readonly PowerSyncData database;
+    private CancellationTokenSource? _watchCts;
 
     public ListsPage(PowerSyncData powerSyncData)
     {
@@ -16,29 +17,39 @@ public partial class ListsPage
         WifiStatusItem.IconImageSource = "wifi_off.png";
     }
 
-    protected override async void OnAppearing()
+    protected override void OnAppearing()
     {
         base.OnAppearing();
 
+        _watchCts?.Cancel();
+        _watchCts = new CancellationTokenSource();
+        var ct = _watchCts.Token;
+
         _ = Task.Run(async () =>
         {
-            await foreach (var update in database.Db.Events.OnStatusChanged.ListenAsync(new CancellationToken()))
+            await foreach (var update in database.Db.Events.OnStatusChanged.ListenAsync(ct))
             {
                 MainThread.BeginInvokeOnMainThread(() =>
                 {
                     WifiStatusItem.IconImageSource = update.Status.Connected ? "wifi.png" : "wifi_off.png";
                 });
             }
-        });
+        }, ct);
 
-        var listener = database.Db.Watch<TodoList>("select * from lists", null, new() { TriggerImmediately = true });
+        var listener = database.Db.Watch<TodoList>("select * from lists", null, new() { TriggerImmediately = true, Signal = ct });
         _ = Task.Run(async () =>
         {
             await foreach (var results in listener)
             {
                 MainThread.BeginInvokeOnMainThread(() => { ListsCollection.ItemsSource = results.ToList(); });
             }
-        });
+        }, ct);
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        _watchCts?.Cancel();
     }
 
     private async void OnAddClicked(object sender, EventArgs e)

--- a/demos/MAUITodo/Views/TodoListPage.xaml
+++ b/demos/MAUITodo/Views/TodoListPage.xaml
@@ -1,14 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="MAUITodo.Views.TodoListPage"
              Title="{Binding ListName}">
     <Grid RowDefinitions="Auto,*">
-        <Button Text="New Todo" 
+        <Button Text="New Todo"
                 Clicked="OnAddClicked"
                 Margin="10"
                 HorizontalOptions="End"/>
-        
+
         <CollectionView Grid.Row="1"
                         x:Name="TodoItemsCollection"
                         SelectionMode="Single"
@@ -16,19 +16,35 @@
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid Padding="10">
-                        <Frame BorderColor="Gray" 
+                        <Frame BorderColor="Gray"
                                Padding="10"
                                CornerRadius="5">
                             <Grid ColumnDefinitions="*,Auto">
                                 <Label Text="{Binding Description}"
                                        FontSize="16"
                                        VerticalOptions="Center"/>
-                                <HorizontalStackLayout Grid.Column="1" 
-                                                     Spacing="10"
-                                                     VerticalOptions="Center">
+                                <HorizontalStackLayout Grid.Column="1"
+                                                       Spacing="10"
+                                                       VerticalOptions="Center">
+                                    <Button Text="No photo"
+                                            CommandParameter="{Binding .}"
+                                            Clicked="OnPhotoClicked"
+                                            IsVisible="{Binding HasNoPhoto}"/>
+                                    <ActivityIndicator IsRunning="{Binding IsDownloading}"
+                                                       IsVisible="{Binding IsDownloading}"
+                                                       WidthRequest="40"
+                                                       HeightRequest="40"
+                                                       Color="Gray"/>
+                                    <ImageButton Source="{Binding PhotoLocalUri}"
+                                                 IsVisible="{Binding IsPhotoReady}"
+                                                 CommandParameter="{Binding .}"
+                                                 Clicked="OnPhotoClicked"
+                                                 WidthRequest="56"
+                                                 HeightRequest="56"
+                                                 Aspect="AspectFill"/>
                                     <CheckBox IsChecked="{Binding Completed}"
-                                             CheckedChanged="OnCheckBoxChanged"
-                                             VerticalOptions="Center"/>
+                                              CheckedChanged="OnCheckBoxChanged"
+                                              VerticalOptions="Center"/>
                                     <Button Text="Delete"
                                             Clicked="OnDeleteClicked"
                                             CommandParameter="{Binding .}"/>

--- a/demos/MAUITodo/Views/TodoListPage.xaml.cs
+++ b/demos/MAUITodo/Views/TodoListPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using MAUITodo.Data;
+using MAUITodo.Data;
 using MAUITodo.Models;
 
 using PowerSync.Common.Client;
@@ -9,6 +9,7 @@ public partial class TodoListPage
 {
     private readonly PowerSyncData database;
     private readonly TodoList selectedList;
+    private CancellationTokenSource? _watchCts;
 
     public TodoListPage(PowerSyncData powerSyncData, TodoList list)
     {
@@ -20,18 +21,37 @@ public partial class TodoListPage
 
     public string ListName => selectedList?.Name ?? "";
 
-    protected override async void OnAppearing()
+    protected override void OnAppearing()
     {
         base.OnAppearing();
 
-        var listener = database.Db.Watch<TodoItem>("select * from todos where list_id = ?", [selectedList.ID], new() { TriggerImmediately = true });
+        _watchCts?.Cancel();
+        _watchCts = new CancellationTokenSource();
+        var ct = _watchCts.Token;
+
+        // attachments is a local-only table; the LEFT JOIN surfaces the locally-synced file path
+        // (if any) for each todo's photo as `photo_local_uri`, which maps to TodoItem.PhotoLocalUri.
+        var listener = database.Db.Watch<TodoItem>(
+            @"SELECT todos.*, attachments.local_uri AS photo_local_uri
+              FROM todos
+              LEFT JOIN attachments ON todos.photo_id = attachments.id
+              WHERE todos.list_id = ?",
+            [selectedList.ID],
+            new() { TriggerImmediately = true, Signal = ct });
+
         _ = Task.Run(async () =>
         {
             await foreach (var results in listener)
             {
                 MainThread.BeginInvokeOnMainThread(() => { TodoItemsCollection.ItemsSource = results.ToList(); });
             }
-        });
+        }, ct);
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        _watchCts?.Cancel();
     }
 
     private async void OnAddClicked(object sender, EventArgs e)
@@ -63,18 +83,54 @@ public partial class TodoListPage
         }
     }
 
+    private async void OnPhotoClicked(object sender, EventArgs e)
+    {
+        var item = sender switch
+        {
+            Button btn => btn.CommandParameter as TodoItem,
+            ImageButton imgBtn => imgBtn.CommandParameter as TodoItem,
+            _ => null
+        };
+        if (item == null) return;
+
+        try
+        {
+            var remove = item.PhotoId != null ? "Remove photo" : null;
+            var choice = await DisplayActionSheet("Photo", "Cancel", remove, "Take photo", "Choose from library");
+
+            if (remove != null && choice == remove)
+            {
+                await database.RemoveTodoPhotoAsync(item.ID, item.PhotoId!);
+                return;
+            }
+
+            var photo = choice switch
+            {
+                "Take photo" => await MediaPicker.Default.CapturePhotoAsync(),
+                "Choose from library" => await MediaPicker.Default.PickPhotoAsync(),
+                _ => null
+            };
+            if (photo == null) return;
+
+            await using var stream = await photo.OpenReadAsync();
+            await database.SaveTodoPhotoAsync(item.ID, stream);
+        }
+        catch (Exception ex)
+        {
+            await DisplayAlert("Error", $"Could not update photo: {ex.Message}", "OK");
+        }
+    }
+
     private async void OnCheckBoxChanged(object sender, CheckedChangedEventArgs e)
     {
         if (sender is CheckBox checkBox && checkBox.Parent?.Parent?.BindingContext is TodoItem todo)
         {
             if (e.Value && todo.CompletedAt == null)
             {
-                todo.Completed = e.Value;
                 await database.SaveTodoCompletedAsync(todo.ID, true);
             }
             else if (e.Value == false && todo.CompletedAt != null)
             {
-                todo.Completed = e.Value;
                 await database.SaveTodoCompletedAsync(todo.ID, false);
             }
         }


### PR DESCRIPTION
Adds attachments functionality to the MAUITodo demo. Uses `${AppDirectory}/attachments` directory for local storage and the [Node.js backend](https://github.com/powersync-ja/powersync-nodejs-backend-todolist-demo) demo's `/api/attachments/:id` path for remote storage.

I tested this by running both an Android and an iOS simulator and observing attachments and syncing behaviour between devices, which seems to be working as intended.

Also see: https://github.com/powersync-ja/powersync-nodejs-backend-todolist-demo/pull/15

### AI Usage

Claude Code built the initial UI and attachments flow. I then reviewed and fixed a number of bugs manually.