### PR TITLE
Lock `MDSQLiteConnection._updateBuffer` before accessing it

### DIFF
--- a/PowerSync/PowerSync.Common/CHANGELOG.md
+++ b/PowerSync/PowerSync.Common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PowerSync.Common Changelog
 
-## 0.1.3-dev.1
+## 0.1.3
 
 - **Breaking:** Made `Table.Name` non-nullable (default ""). This change may affect 0% of users, but it is technically a breaking change.
 - Add support for loading custom SQLite extensions via `MDSQLiteOptions.Extensions`.

--- a/PowerSync/PowerSync.Common/CHANGELOG.md
+++ b/PowerSync/PowerSync.Common/CHANGELOG.md
@@ -1,10 +1,11 @@
 # PowerSync.Common Changelog
 
-## 0.1.3
+## 0.1.3-dev.1
 
 - **Breaking:** Made `Table.Name` non-nullable (default ""). This change may affect 0% of users, but it is technically a breaking change.
 - Add support for loading custom SQLite extensions via `MDSQLiteOptions.Extensions`.
 - Fix streaming sync retry loop reconnecting with no delay after an exception, ignoring `RetryDelayMs`.
+- Lock `MDSQLiteConnection._updateBuffer` to fix a rare issue with high-frequency local writes while syncing.
 - (internal) Remove `Compiled*` classes in favor of working with `Table` and `Schema` objects directly.
 
 ## 0.1.2

--- a/PowerSync/PowerSync.Common/MDSQLite/MDSQLiteConnection.cs
+++ b/PowerSync/PowerSync.Common/MDSQLite/MDSQLiteConnection.cs
@@ -21,11 +21,12 @@ public class MDSQLiteConnectionOptions(SqliteConnection database)
 public class MDSQLiteConnection : EventStream<DBAdapterEvents.TablesUpdatedEvent>, ILockContext
 {
     public SqliteConnection Db;
-    private readonly List<UpdateNotification> updateBuffer;
+    private readonly List<UpdateNotification> _updateBuffer;
+    private readonly object _updateBufferLock = new();
     public MDSQLiteConnection(MDSQLiteConnectionOptions options)
     {
         Db = options.Database;
-        updateBuffer = [];
+        _updateBuffer = [];
 
         raw.sqlite3_rollback_hook(Db.Handle, RollbackHook, IntPtr.Zero);
         raw.sqlite3_update_hook(Db.Handle, UpdateHook, IntPtr.Zero);
@@ -33,7 +34,10 @@ public class MDSQLiteConnection : EventStream<DBAdapterEvents.TablesUpdatedEvent
 
     private void RollbackHook(object user_data)
     {
-        updateBuffer.Clear();
+        lock (_updateBufferLock)
+        {
+            _updateBuffer.Clear();
+        }
     }
 
     private void UpdateHook(object user_data, int type, utf8z database, utf8z table, long rowId)
@@ -45,17 +49,26 @@ public class MDSQLiteConnection : EventStream<DBAdapterEvents.TablesUpdatedEvent
             23 => RowUpdateType.SQLITE_UPDATE,
             _ => throw new InvalidOperationException($"Unknown update type: {type}"),
         };
-        updateBuffer.Add(new UpdateNotification(table.utf8_to_string(), opType, rowId));
+        lock (_updateBufferLock)
+        {
+            _updateBuffer.Add(new UpdateNotification(table.utf8_to_string(), opType, rowId));
+        }
     }
 
     public void FlushUpdates()
     {
-        if (updateBuffer.Count == 0)
+        UpdateNotification[] updates;
+        lock (_updateBufferLock)
         {
-            return;
+            if (_updateBuffer.Count == 0)
+            {
+                return;
+            }
+            updates = _updateBuffer.ToArray();
+            _updateBuffer.Clear();
         }
 
-        var groupedUpdates = updateBuffer
+        var groupedUpdates = updates
             .GroupBy(update => update.Table)
             .ToDictionary(
                 group => group.Key,
@@ -65,11 +78,10 @@ public class MDSQLiteConnection : EventStream<DBAdapterEvents.TablesUpdatedEvent
         var batchedUpdate = new BatchedUpdateNotification
         {
             GroupedUpdates = groupedUpdates,
-            RawUpdates = updateBuffer.ToArray(),
+            RawUpdates = updates.ToArray(),
             Tables = groupedUpdates.Keys.ToArray()
         };
 
-        updateBuffer.Clear();
         Emit(new DBAdapterEvents.TablesUpdatedEvent(batchedUpdate));
     }
 

--- a/PowerSync/PowerSync.Maui/CHANGELOG.md
+++ b/PowerSync/PowerSync.Maui/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PowerSync.Maui Changelog
 
-## 0.1.3-dev.1
+## 0.1.3
 
 - Upstream PowerSync.Common version bump (See Powersync.Common changelog 0.1.3 for more information)
 

--- a/PowerSync/PowerSync.Maui/CHANGELOG.md
+++ b/PowerSync/PowerSync.Maui/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PowerSync.Maui Changelog
 
-## 0.1.3
+## 0.1.3-dev.1
 
 - Upstream PowerSync.Common version bump (See Powersync.Common changelog 0.1.3 for more information)
 


### PR DESCRIPTION
Fixes #75.

The `FlushUpdates` method in `MDSQLiteConnection` enumerates the `_updateBuffer` property using LINQ, but this can fail if `_updateBuffer` is modified partway through the enumeration. It also calls `_updateBuffer.Clear()` at the end of the function, which means any updates triggered between `_updateBuffer` being enumerated and `_updateBuffer` being cleared are dropped.

This PR adds a lock around `_updateBuffer` and wraps all reads and writes of `_updateBuffer` in said lock. I considered using a `ConcurrentQueue`, but we would need a workaround for `ConcurrentQueue.Clear()` since that method doesn't exist in .NET Standard 2.0 (it would probably also be slower).