### PR TITLE
Create draft GH release + safer releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,10 @@ jobs:
         shell: bash
         run: |
           COMMON_VERSION=$(awk '/^## [0-9]+\.[0-9]+\.[0-9]+/ {print $2; exit}' PowerSync/PowerSync.Common/CHANGELOG.md)
+          if [[ -z "$COMMON_VERSION" ]]; then
+            echo "Error: Invalid version found in PowerSync.Common/CHANGELOG.md. Expected format: '## x.x.x'"
+            exit 1
+          fi
           echo "Detected Version: $COMMON_VERSION"
           echo "VERSION=$COMMON_VERSION" >> $GITHUB_ENV
           echo "COMMON_VERSION=$COMMON_VERSION" >> $GITHUB_ENV
@@ -53,6 +57,10 @@ jobs:
         shell: bash
         run: |
           MAUI_VERSION=$(awk '/^## [0-9]+\.[0-9]+\.[0-9]+/ {print $2; exit}' PowerSync/PowerSync.Maui/CHANGELOG.md)
+          if [[ -z "$MAUI_VERSION" ]]; then
+            echo "Error: Invalid version found in PowerSync.Maui/CHANGELOG.md. Expected format: '## x.x.x'"
+            exit 1
+          fi
           echo "Detected Version: $MAUI_VERSION"
           echo "VERSION=$MAUI_VERSION" >> $GITHUB_ENV
           echo "MAUI_VERSION=$MAUI_VERSION" >> $GITHUB_ENV
@@ -72,11 +80,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "PowerSync.Common@${{ env.COMMON_VERSION }}" \
+            --draft \
             --title "PowerSync.Common@${{ env.COMMON_VERSION }}" \
             --target main \
             --generate-notes \
             ${{ github.workspace }}/output/PowerSync.Common*.nupkg
           gh release create "PowerSync.Maui@${{ env.MAUI_VERSION }}" \
+            --draft \
             --title "PowerSync.Maui@${{ env.MAUI_VERSION }}" \
             --target main \
             --generate-notes \


### PR DESCRIPTION
Creates a draft Github release on `release.yml` run instead of an immediately published release. Also adds the same `if [[ -z "$*_VERSION" ]]` check from the dev release workflow to the regular release workflow to prevent calling `dotnet nuget push` with an invalid/empty version.