### PR TITLE
Add internal `WatchManager` class

### DIFF
--- a/PowerSync/PowerSync.Common/Client/PowerSyncDatabase.cs
+++ b/PowerSync/PowerSync.Common/Client/PowerSyncDatabase.cs
@@ -1,16 +1,13 @@
 namespace PowerSync.Common.Client;
 
-using System.Runtime.CompilerServices;
-using System.Text.RegularExpressions;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 using Newtonsoft.Json;
+
 using Nito.AsyncEx;
-using ThrottleDebounce;
 
 using PowerSync.Common.Client.Connection;
 using PowerSync.Common.Client.Sync.Bucket;
@@ -132,9 +129,6 @@ public class PowerSyncDatabase : IPowerSyncDatabase
     public IDBAdapter Database { get; protected set; }
     private Schema schema;
 
-    private const int DEFAULT_WATCH_THROTTLE_MS = 30;
-    private static readonly Regex POWERSYNC_TABLE_MATCH = new Regex(@"(^ps_data__|^ps_data_local__)", RegexOptions.Compiled);
-
     public bool Closed { get; protected set; }
     public bool Ready { get; protected set; }
 
@@ -144,6 +138,8 @@ public class PowerSyncDatabase : IPowerSyncDatabase
     protected ConnectionManager ConnectionManager;
 
     private readonly InternalSubscriptionManager subscriptions;
+
+    private readonly WatchManager watchManager;
 
     private StreamingSyncImplementation? syncStreamImplementation;
     public string SdkVersion { get; protected set; }
@@ -203,6 +199,8 @@ public class PowerSyncDatabase : IPowerSyncDatabase
         SdkVersion = "";
 
         remoteFactory = options.RemoteFactory ?? (connector => new Remote(connector));
+
+        watchManager = new WatchManager(this, masterCts.Token);
 
         // Start async init
         subscriptions = new InternalSubscriptionManager(
@@ -344,7 +342,9 @@ public class PowerSyncDatabase : IPowerSyncDatabase
     {
         await BucketStorageAdapter.Init();
         await LoadVersion();
-        await UpdateSchema(options.Schema);
+        // Note: no SchemaChangedEvent here - watched queries only resolve their source tables
+        // once initialization has completed, so the initial schema is never stale for them.
+        await ReplaceSchema(options.Schema);
         await ResolveOfflineSyncStatus();
         await Database.Execute("PRAGMA RECURSIVE_TRIGGERS=TRUE");
         Ready = true;
@@ -407,6 +407,12 @@ public class PowerSyncDatabase : IPowerSyncDatabase
             throw new Exception("Cannot update schema while connected");
         }
 
+        await ReplaceSchema(schema);
+        Events.Emit(new PowerSyncDBEvents.SchemaChangedEvent(schema));
+    }
+
+    private async Task ReplaceSchema(Schema schema)
+    {
         try
         {
             schema.Validate();
@@ -419,7 +425,6 @@ public class PowerSyncDatabase : IPowerSyncDatabase
         this.schema = schema;
         await Database.Execute("SELECT powersync_replace_schema(?)", [JsonConvert.SerializeObject(schema)]);
         await Database.RefreshSchema();
-        Events.Emit(new PowerSyncDBEvents.SchemaChangedEvent(schema));
     }
 
     /// <summary>
@@ -768,192 +773,24 @@ public class PowerSyncDatabase : IPowerSyncDatabase
         return await Database.WriteTransaction(fn, options);
     }
 
+    /// <summary>
+    /// Executes a read query every time the source tables are modified.
+    ///
+    /// The query's source tables are resolved automatically (or taken from
+    /// <see cref="SQLWatchOptions.Tables"/> when provided), and are re-resolved whenever the
+    /// schema changes, so watches keep working across <see cref="UpdateSchema"/> calls.
+    /// </summary>
+    public IAsyncEnumerable<T[]> Watch<T>(string sql, object?[]? parameters = null, SQLWatchOptions? options = null)
+    {
+        return watchManager.Watch<T>(sql, parameters, options);
+    }
+
+    /// <summary>
+    /// Emits an event whenever any of the tables in <see cref="SQLWatchOptions.Tables"/> are modified.
+    /// </summary>
     public IAsyncEnumerable<WatchOnChangeEvent> OnChange(SQLWatchOptions? options = null)
     {
-        options ??= new SQLWatchOptions();
-
-        var tables = options?.Tables ?? [];
-        var powersyncTables = new HashSet<string>(
-            tables.SelectMany(table => new[] { $"ps_data__{table}", $"ps_data_local__{table}" })
-        );
-
-        var signal = options?.Signal != null
-            ? CancellationTokenSource.CreateLinkedTokenSource(masterCts.Token, options.Signal.Value)
-            : CancellationTokenSource.CreateLinkedTokenSource(masterCts.Token);
-
-        var listener = Database.Events.OnTablesUpdated.ListenAsync(signal.Token);
-
-        // Return the actual IAsyncEnumerable here, using OnChange as a synchronous wrapper that blocks until the
-        // connection is established
-        var throttleMs = options?.ThrottleMs ?? DEFAULT_WATCH_THROTTLE_MS;
-        return OnChangeCore(powersyncTables, listener, signal, options?.TriggerImmediately == true, throttleMs);
-    }
-
-    private async IAsyncEnumerable<WatchOnChangeEvent> OnChangeCore(
-        HashSet<string> watchedTables,
-        IAsyncEnumerable<DBAdapterEvents.TablesUpdatedEvent> listener,
-        CancellationTokenSource signal,
-        bool triggerImmediately,
-        int throttleMs = DEFAULT_WATCH_THROTTLE_MS
-    )
-    {
-        try
-        {
-            await foreach (var update in OnRawTableChange(watchedTables, listener, signal.Token, triggerImmediately, throttleMs))
-            {
-                // Convert from 'ps_data__<name>' to '<name>'
-                for (int i = 0; i < update.ChangedTables.Length; i++)
-                {
-                    update.ChangedTables[i] = InternalToFriendlyTableName(update.ChangedTables[i]);
-                }
-                yield return update;
-            }
-        }
-        finally
-        {
-            signal.Dispose();
-        }
-    }
-
-    private static string InternalToFriendlyTableName(string internalName)
-    {
-        const string PS_DATA_PREFIX = "ps_data__";
-        const string PS_DATA_LOCAL_PREFIX = "ps_data_local__";
-
-        if (internalName.StartsWith(PS_DATA_PREFIX))
-            return internalName.Substring(PS_DATA_PREFIX.Length);
-
-        if (internalName.StartsWith(PS_DATA_LOCAL_PREFIX))
-            return internalName.Substring(PS_DATA_LOCAL_PREFIX.Length);
-
-        return internalName;
-    }
-
-    public IAsyncEnumerable<T[]> Watch<T>(
-        string sql,
-        object?[]? parameters = null,
-        SQLWatchOptions? options = null
-    )
-    {
-        options ??= new SQLWatchOptions();
-
-        // Stop watching on master CTS cancellation, or on user CTS cancellation
-        var signal = options.Signal != null
-            ? CancellationTokenSource.CreateLinkedTokenSource(masterCts.Token, options.Signal.Value)
-            : CancellationTokenSource.CreateLinkedTokenSource(masterCts.Token);
-
-        // Establish the initial DB listener synchronously before returning the IAsyncEnumerable,
-        // so that table changes between Watch() being called and iteration starting are not missed.
-        // This mirrors the pattern used in OnChange().
-        var initialRestartCts = CancellationTokenSource.CreateLinkedTokenSource(signal.Token);
-        var initialListener = Database.Events.OnTablesUpdated.ListenAsync(initialRestartCts.Token);
-
-        return WatchCore<T>(sql, parameters, options, signal, initialRestartCts, initialListener);
-    }
-
-    private async IAsyncEnumerable<T[]> WatchCore<T>(
-        string sql,
-        object?[]? parameters,
-        SQLWatchOptions options,
-        CancellationTokenSource signal,
-        CancellationTokenSource initialRestartCts,
-        IAsyncEnumerable<DBAdapterEvents.TablesUpdatedEvent> initialListener
-    )
-    {
-        var schemaChanged = new TaskCompletionSource<bool>();
-
-        // Listen for schema changes in the background
-        var schemaListenerTask = Task.Run(async () =>
-        {
-            await foreach (var update in Events.OnSchemaChanged.ListenAsync(signal.Token))
-            {
-                // Swap schemaChanged with an unresolved TCS
-                var oldTcs = Interlocked.Exchange(ref schemaChanged, new());
-                oldTcs.TrySetResult(true);
-            }
-        }, signal.Token);
-
-        // Re-register query on schema updates
-        bool isRestart = false;
-        var currentRestartCts = initialRestartCts;
-        var currentListener = initialListener;
-        var throttleMs = options?.ThrottleMs ?? DEFAULT_WATCH_THROTTLE_MS;
-
-        try
-        {
-            while (!signal.Token.IsCancellationRequested)
-            {
-                // Resolve tables
-                HashSet<string> powersyncTables;
-                if (options?.Tables != null)
-                {
-                    powersyncTables = [.. options
-                        .Tables
-                        .SelectMany<string, string>(table => [$"ps_data__{table}", $"ps_data_local__{table}"]
-                    )];
-                }
-                else
-                {
-                    powersyncTables = await GetSourceTables(sql, parameters);
-                }
-
-                var enumerator = OnRawTableChange(
-                    powersyncTables,
-                    currentListener,
-                    currentRestartCts.Token,
-                    isRestart || (options?.TriggerImmediately == true),
-                    throttleMs
-                ).GetAsyncEnumerator();
-
-                // Continually wait for either OnChange or SchemaChanged to fire
-                while (true)
-                {
-                    var currentSchemaTask = schemaChanged.Task;
-                    var onChangeTask = enumerator.MoveNextAsync().AsTask();
-                    var completedTask = await Task.WhenAny(onChangeTask, currentSchemaTask);
-
-                    if (completedTask == currentSchemaTask)
-                    {
-                        var oldRestartCts = currentRestartCts;
-                        oldRestartCts.Cancel();
-                        isRestart = true;
-                        // Let the current task complete/cancel gracefully
-                        try { await onChangeTask; }
-                        catch (OperationCanceledException) { }
-
-                        // Establish a new listener BEFORE resolving source tables in the next iteration,
-                        // so that changes during the async GetSourceTables call are not missed.
-                        currentRestartCts = CancellationTokenSource.CreateLinkedTokenSource(signal.Token);
-                        currentListener = Database.Events.OnTablesUpdated.ListenAsync(currentRestartCts.Token);
-                        oldRestartCts.Dispose();
-
-                        break;
-                    }
-
-                    // Await onChangeTask to propagate cancellation and detect end-of-enumeration
-                    bool hasNext;
-                    try { hasNext = await onChangeTask; }
-                    catch (OperationCanceledException) { yield break; }
-
-                    if (!hasNext) break;
-
-                    var update = enumerator.Current;
-                    if (update.ChangedTables != null)
-                    {
-                        yield return await GetAll<T>(sql, parameters);
-                    }
-                }
-            }
-        }
-        finally
-        {
-            signal.Cancel();
-            try { await schemaListenerTask; }
-            catch (OperationCanceledException) { }
-
-            currentRestartCts.Dispose();
-            signal.Dispose();
-        }
+        return watchManager.OnChange(options);
     }
 
     private class ExplainedResult
@@ -984,112 +821,6 @@ public class PowerSyncDatabase : IPowerSyncDatabase
         );
 
         return [.. tables.Select(row => row.tbl_name)];
-    }
-
-    private async IAsyncEnumerable<WatchOnChangeEvent> OnRawTableChange(
-        HashSet<string> watchedTables,
-        IAsyncEnumerable<DBAdapterEvents.TablesUpdatedEvent> listener,
-        [EnumeratorCancellation] CancellationToken signal,
-        bool triggerImmediately = false,
-        int throttleMs = DEFAULT_WATCH_THROTTLE_MS
-    )
-    {
-        if (triggerImmediately)
-        {
-            yield return new WatchOnChangeEvent { ChangedTables = [] };
-        }
-
-        if (throttleMs <= 0)
-        {
-            // No throttling
-            HashSet<string> changedTables = new();
-            await foreach (var e in listener)
-            {
-                GetTablesFromNotification(e.TablesUpdated, changedTables);
-                changedTables.IntersectWith(watchedTables);
-                if (changedTables.Count == 0) continue;
-                yield return new WatchOnChangeEvent { ChangedTables = [.. changedTables] };
-            }
-            yield break;
-        }
-
-        // Throttled - publish via throttled call to an action that flushes accumulated changes into this channel
-        var channel = Channel.CreateUnbounded<WatchOnChangeEvent>();
-        var accumulatedTables = new HashSet<string>();
-
-        _ = Task.Run(async () =>
-        {
-            using var throttledFlush = Throttler.Throttle(() =>
-                {
-                    // Safe to lock directly on accumulatedTables because it's a local variable
-                    lock (accumulatedTables)
-                    {
-                        if (accumulatedTables.Count == 0) return;
-                        channel.Writer.TryWrite(new WatchOnChangeEvent { ChangedTables = [.. accumulatedTables] });
-                        accumulatedTables.Clear();
-                    }
-                },
-                TimeSpan.FromMilliseconds(throttleMs),
-                leading: false,
-                trailing: true
-            );
-
-            try
-            {
-                var changedTables = new HashSet<string>();
-                await foreach (var e in listener)
-                {
-                    GetTablesFromNotification(e.TablesUpdated, changedTables);
-                    changedTables.IntersectWith(watchedTables);
-                    if (changedTables.Count == 0) continue;
-
-                    lock (accumulatedTables) { accumulatedTables.UnionWith(changedTables); }
-                    throttledFlush.Invoke();
-                }
-            }
-            catch (OperationCanceledException) { }
-            finally
-            {
-                // Flush any remaining events and close the channel
-                lock (accumulatedTables)
-                {
-                    if (accumulatedTables.Count > 0)
-                    {
-                        channel.Writer.TryWrite(new WatchOnChangeEvent { ChangedTables = [.. accumulatedTables] });
-                        accumulatedTables.Clear();
-                    }
-                }
-                channel.Writer.Complete();
-            }
-        });
-
-        // Continuously pull values from channel and publish to the consumer
-        while (await channel.Reader.WaitToReadAsync(CancellationToken.None))
-        {
-            while (channel.Reader.TryRead(out var evt))
-            {
-                yield return evt;
-            }
-        }
-    }
-
-    private static void GetTablesFromNotification(INotification updateNotification, HashSet<string> changedTables)
-    {
-        changedTables.Clear();
-        string[] tables = [];
-        if (updateNotification is BatchedUpdateNotification batchedUpdate)
-        {
-            tables = batchedUpdate.Tables;
-        }
-        else if (updateNotification is UpdateNotification singleUpdate)
-        {
-            tables = [singleUpdate.Table];
-        }
-
-        foreach (var table in tables)
-        {
-            changedTables.Add(table);
-        }
     }
 }
 

--- a/PowerSync/PowerSync.Common/Client/WatchManager.cs
+++ b/PowerSync/PowerSync.Common/Client/WatchManager.cs
@@ -1,0 +1,418 @@
+namespace PowerSync.Common.Client;
+
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+
+using Microsoft.Extensions.Logging;
+
+using PowerSync.Common.DB;
+
+/// <summary>
+/// Owns all watched queries for a <see cref="PowerSyncDatabase"/>.
+///
+/// A single listener on the DB adapter's table-update events dispatches changes to each
+/// registered <see cref="WatchSubscription"/>, and a single listener on schema changes marks
+/// every subscription's resolved source tables as stale. Subscriptions are otherwise fully
+/// independent: each one throttles, re-resolves its source tables and re-runs its query on
+/// its own consumer-driven loop, so a slow or failing query only affects its own stream.
+/// </summary>
+internal class WatchManager
+{
+    internal const int DEFAULT_THROTTLE_MS = 30;
+
+    private const string PS_DATA_PREFIX = "ps_data__";
+    private const string PS_DATA_LOCAL_PREFIX = "ps_data_local__";
+
+    private readonly PowerSyncDatabase db;
+    private readonly CancellationToken masterToken;
+    private readonly ConcurrentDictionary<WatchSubscription, byte> watches = new();
+
+    public WatchManager(PowerSyncDatabase db, CancellationToken masterToken)
+    {
+        this.db = db;
+        this.masterToken = masterToken;
+
+        // Dispatch two tasks, one for TableUpdated events and one for SchemaChanged events
+        _ = Task.Run(RunTableUpdateLoop);
+        _ = Task.Run(RunSchemaChangeLoop);
+    }
+
+    public IAsyncEnumerable<T[]> Watch<T>(string sql, object?[]? parameters, SQLWatchOptions? options)
+    {
+        options ??= new SQLWatchOptions();
+
+        // Register synchronously so that table changes between this call and the consumer
+        // starting iteration are not missed.
+        var subscription = CreateSubscription(
+            options,
+            resolveTables: options.Tables != null
+                ? () => Task.FromResult(ExpandTableNames(options.Tables))
+                : () => db.GetSourceTables(sql, parameters),
+            initialTables: options.Tables != null ? ExpandTableNames(options.Tables) : null,
+            // Don't flush updates mid-cancellation, since that may involve expensive
+            // database operations.
+            flushOnCancel: false
+        );
+
+        return Stream(subscription, _ => db.GetAll<T>(sql, parameters));
+    }
+
+    public IAsyncEnumerable<WatchOnChangeEvent> OnChange(SQLWatchOptions? options)
+    {
+        options ??= new SQLWatchOptions();
+
+        var tables = ExpandTableNames(options.Tables ?? []);
+        var subscription = CreateSubscription(
+            options,
+            resolveTables: () => Task.FromResult(new HashSet<string>(tables)),
+            initialTables: tables,
+            // Deliver changes accumulated during the throttle window even if cancellation
+            // lands before the window expires.
+            flushOnCancel: true
+        );
+
+        return Stream(subscription, changed => Task.FromResult(new WatchOnChangeEvent
+        {
+            ChangedTables = [.. changed.Select(InternalToFriendlyTableName)]
+        }));
+    }
+
+    private WatchSubscription CreateSubscription(
+        SQLWatchOptions options,
+        Func<Task<HashSet<string>>> resolveTables,
+        HashSet<string>? initialTables,
+        bool flushOnCancel
+    )
+    {
+        var cts = options.Signal != null
+            ? CancellationTokenSource.CreateLinkedTokenSource(masterToken, options.Signal.Value)
+            : CancellationTokenSource.CreateLinkedTokenSource(masterToken);
+
+        var subscription = new WatchSubscription(
+            resolveTables,
+            initialTables,
+            options.ThrottleMs ?? DEFAULT_THROTTLE_MS,
+            options.TriggerImmediately,
+            flushOnCancel,
+            cts
+        );
+
+        watches.TryAdd(subscription, 0);
+
+        // Cleanup must not depend on the consumer ever iterating the stream: on any cancellation
+        // (external Signal, master token, or Unregister) drop the subscription from the registry.
+        // CTS disposal stays in Unregister - disposing from inside a cancellation callback is unsafe.
+        cts.Token.Register(() => watches.TryRemove(subscription, out _));
+
+        return subscription;
+    }
+
+    private void Unregister(WatchSubscription subscription)
+    {
+        if (!subscription.TryClose()) return;
+
+        watches.TryRemove(subscription, out _);
+        subscription.Cts.Cancel();
+        subscription.Cts.Dispose();
+    }
+
+    private async IAsyncEnumerable<T> Stream<T>(WatchSubscription subscription, Func<HashSet<string>, Task<T>> onChange)
+    {
+        try
+        {
+            while (true)
+            {
+                var changed = await subscription.WaitForChangeAsync();
+                if (changed == null) yield break;
+
+                yield return await onChange(changed);
+            }
+        }
+        finally
+        {
+            Unregister(subscription);
+        }
+    }
+
+    private async Task RunTableUpdateLoop()
+    {
+        try
+        {
+            await foreach (var update in db.Database.Events.OnTablesUpdated.ListenAsync(masterToken))
+            {
+                // Prevent a single bad notification from taking down the entire TablesUpdated loop
+                try
+                {
+                    var changed = new HashSet<string>(DBAdapterUtils.ExtractTableUpdates(update.TablesUpdated));
+                    if (changed.Count == 0) continue;
+
+                    foreach (var entry in watches)
+                    {
+                        entry.Key.NotifyTablesChanged(changed);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    db.Logger.LogError(ex, "Failed to dispatch a table update to watched queries.");
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex)
+        {
+            db.Logger.LogError(ex, "Watch OnTablesUpdated dispatcher failed; terminating all watched queries.");
+        }
+        finally
+        {
+            foreach (var entry in watches)
+            {
+                watches.TryRemove(entry.Key, out _);
+                entry.Key.Terminate();
+            }
+        }
+    }
+
+    private async Task RunSchemaChangeLoop()
+    {
+        try
+        {
+            await foreach (var _ in db.Events.OnSchemaChanged.ListenAsync(masterToken))
+            {
+                foreach (var entry in watches)
+                {
+                    entry.Key.RequestRefresh();
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex)
+        {
+            db.Logger.LogError(ex, "Watch OnSchemaChanged dispatcher failed; watched queries will not react to schema changes.");
+        }
+    }
+
+    private static HashSet<string> ExpandTableNames(IEnumerable<string> tables) =>
+        [.. tables.SelectMany(table => new[] { $"{PS_DATA_PREFIX}{table}", $"{PS_DATA_LOCAL_PREFIX}{table}" })];
+
+    private static string InternalToFriendlyTableName(string internalName)
+    {
+        if (internalName.StartsWith(PS_DATA_PREFIX))
+            return internalName.Substring(PS_DATA_PREFIX.Length);
+
+        if (internalName.StartsWith(PS_DATA_LOCAL_PREFIX))
+            return internalName.Substring(PS_DATA_LOCAL_PREFIX.Length);
+
+        return internalName;
+    }
+}
+
+/// <summary>
+/// Dispatch state for a single watched query.
+///
+/// The manager pushes changed table names in via <see cref="NotifyTablesChanged"/> and schema
+/// resets via <see cref="RequestRefresh"/>; the consumer pulls coalesced change batches out via
+/// <see cref="WaitForChangeAsync"/>. Throttling is per-subscription: the signal channel has a
+/// capacity of one, so any number of notifications during the throttle window or an in-flight
+/// query collapse into a single pending wake-up.
+/// </summary>
+internal class WatchSubscription
+{
+    private readonly object mutex = new();
+    private readonly Channel<bool> signal = Channel.CreateBounded<bool>(
+        new BoundedChannelOptions(1) { FullMode = BoundedChannelFullMode.DropWrite }
+    );
+
+    private readonly Func<Task<HashSet<string>>> resolveTables;
+    private readonly int throttleMs;
+    private readonly bool flushOnCancel;
+    // Static table sets (explicit SQLWatchOptions.Tables) survive schema refreshes: only the
+    // underlying data changes, never the expansion, so a refresh re-runs the query without
+    // discarding the set.
+    private readonly bool staticTables;
+
+    private int closed;
+
+    // The resolved source tables of the query. Null means "not resolved" - either not yet
+    // resolved, or invalidated by a schema change. While null, all table notifications are
+    // accumulated unfiltered and filtered against the newly resolved set later, so no
+    // relevant change is missed during (re)resolution.
+    private HashSet<string>? tables;
+    private HashSet<string> pending = [];
+    private bool refreshRequested;
+
+    internal CancellationTokenSource Cts { get; }
+
+    public WatchSubscription(
+        Func<Task<HashSet<string>>> resolveTables,
+        HashSet<string>? initialTables,
+        int throttleMs,
+        bool triggerImmediately,
+        bool flushOnCancel,
+        CancellationTokenSource cts
+    )
+    {
+        this.resolveTables = resolveTables;
+        this.throttleMs = throttleMs;
+        this.flushOnCancel = flushOnCancel;
+        staticTables = initialTables != null;
+        tables = initialTables;
+        Cts = cts;
+
+        if (triggerImmediately)
+        {
+            refreshRequested = true;
+            signal.Writer.TryWrite(true);
+        }
+    }
+
+    public void NotifyTablesChanged(HashSet<string> changed)
+    {
+        lock (mutex)
+        {
+            if (tables == null)
+            {
+                pending.UnionWith(changed);
+            }
+            else
+            {
+                var relevant = false;
+                foreach (var table in changed)
+                {
+                    if (tables.Contains(table))
+                    {
+                        pending.Add(table);
+                        relevant = true;
+                    }
+                }
+                if (!relevant) return;
+            }
+        }
+        signal.Writer.TryWrite(true);
+    }
+
+    public void RequestRefresh()
+    {
+        lock (mutex)
+        {
+            refreshRequested = true;
+            if (!staticTables) tables = null;
+        }
+        signal.Writer.TryWrite(true);
+    }
+
+    /// <summary>
+    /// Ends the subscription's stream gracefully without cancelling it: any pending batch is
+    /// still delivered, then <see cref="WaitForChangeAsync"/> returns null. Used when the
+    /// dispatcher can no longer deliver updates.
+    /// </summary>
+    public void Terminate()
+    {
+        signal.Writer.TryComplete();
+    }
+
+    /// <summary>
+    /// Marks the subscription closed. Returns false if it was already closed, making
+    /// unregistration idempotent across multiple enumerations of the same stream.
+    /// </summary>
+    public bool TryClose()
+    {
+        return Interlocked.Exchange(ref closed, 1) == 0;
+    }
+
+    /// <summary>
+    /// Waits for the next batch of relevant table changes, applying the throttle window.
+    /// Returns the changed table names (empty for refresh/immediate triggers, where the query
+    /// must run regardless of which tables changed), or null when the subscription ends.
+    /// </summary>
+    public async Task<HashSet<string>?> WaitForChangeAsync()
+    {
+        while (true)
+        {
+            try
+            {
+                if (!await signal.Reader.WaitToReadAsync(Cts.Token)) return null;
+            }
+            catch (OperationCanceledException)
+            {
+                return FlushPendingOnCancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // A prior enumeration of the same stream already unregistered this subscription
+                return null;
+            }
+
+            bool refresh;
+            lock (mutex) refresh = refreshRequested;
+
+            // Refresh and TriggerImmediately wake-ups bypass the throttle so that consumers see
+            // post-schema-change results (and initial results) without delay.
+            if (!refresh && throttleMs > 0)
+            {
+                try
+                {
+                    await Task.Delay(throttleMs, Cts.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    return FlushPendingOnCancel();
+                }
+                catch (ObjectDisposedException)
+                {
+                    return null;
+                }
+            }
+
+            // Consume the signal only after the throttle window, so notifications that arrived
+            // during the window coalesce into this batch instead of causing another wake-up.
+            signal.Reader.TryRead(out _);
+
+            HashSet<string> batch;
+            HashSet<string>? currentTables;
+            lock (mutex)
+            {
+                refresh = refreshRequested;
+                refreshRequested = false;
+                batch = pending;
+                pending = [];
+                currentTables = tables;
+            }
+
+            if (currentTables == null)
+            {
+                currentTables = await resolveTables();
+                lock (mutex)
+                {
+                    // A concurrent RequestRefresh may have nulled `tables` again; don't clobber it,
+                    // the next wake-up will re-resolve.
+                    if (!refreshRequested) tables = currentTables;
+                }
+            }
+
+            // Names accumulated while unresolved are unfiltered; restrict them to the actual
+            // source tables. Already-filtered names are unaffected.
+            batch.IntersectWith(currentTables);
+
+            if (refresh) return batch;
+            if (batch.Count == 0) continue;
+            return batch;
+        }
+    }
+
+    private HashSet<string>? FlushPendingOnCancel()
+    {
+        if (!flushOnCancel) return null;
+
+        lock (mutex)
+        {
+            if (tables == null) return null;
+
+            pending.IntersectWith(tables);
+            if (pending.Count == 0) return null;
+
+            var batch = pending;
+            pending = [];
+            return batch;
+        }
+    }
+}

--- a/PowerSync/PowerSync.Common/Client/WatchManager.cs
+++ b/PowerSync/PowerSync.Common/Client/WatchManager.cs
@@ -51,7 +51,8 @@ internal class WatchManager
             initialTables: options.Tables != null ? ExpandTableNames(options.Tables) : null,
             // Don't flush updates mid-cancellation, since that may involve expensive
             // database operations.
-            flushOnCancel: false
+            flushOnCancel: false,
+            refreshOnSchemaChange: true
         );
 
         return Stream(subscription, _ => db.GetAll<T>(sql, parameters));
@@ -68,9 +69,12 @@ internal class WatchManager
             initialTables: tables,
             // Deliver changes accumulated during the throttle window even if cancellation
             // lands before the window expires.
-            flushOnCancel: true
+            flushOnCancel: true,
+            refreshOnSchemaChange: false
         );
 
+        // TODO: powersync-js onChange returns table names in `ps_data__{table}` format.
+        //       We should make a decision on whether or not to mirror that before v1.
         return Stream(subscription, changed => Task.FromResult(new WatchOnChangeEvent
         {
             ChangedTables = [.. changed.Select(InternalToFriendlyTableName)]
@@ -81,7 +85,8 @@ internal class WatchManager
         SQLWatchOptions options,
         Func<Task<HashSet<string>>> resolveTables,
         HashSet<string>? initialTables,
-        bool flushOnCancel
+        bool flushOnCancel,
+        bool refreshOnSchemaChange
     )
     {
         var cts = options.Signal != null
@@ -94,6 +99,7 @@ internal class WatchManager
             options.ThrottleMs ?? DEFAULT_THROTTLE_MS,
             options.TriggerImmediately,
             flushOnCancel,
+            refreshOnSchemaChange,
             cts
         );
 
@@ -225,6 +231,7 @@ internal class WatchSubscription
     private readonly Func<Task<HashSet<string>>> resolveTables;
     private readonly int throttleMs;
     private readonly bool flushOnCancel;
+    private readonly bool refreshOnSchemaChange;
     // Static table sets (explicit SQLWatchOptions.Tables) survive schema refreshes: only the
     // underlying data changes, never the expansion, so a refresh re-runs the query without
     // discarding the set.
@@ -248,12 +255,14 @@ internal class WatchSubscription
         int throttleMs,
         bool triggerImmediately,
         bool flushOnCancel,
+        bool refreshOnSchemaChange,
         CancellationTokenSource cts
     )
     {
         this.resolveTables = resolveTables;
         this.throttleMs = throttleMs;
         this.flushOnCancel = flushOnCancel;
+        this.refreshOnSchemaChange = refreshOnSchemaChange;
         staticTables = initialTables != null;
         tables = initialTables;
         Cts = cts;
@@ -294,6 +303,8 @@ internal class WatchSubscription
     {
         lock (mutex)
         {
+            if (!refreshOnSchemaChange) return;
+
             refreshRequested = true;
             if (!staticTables) tables = null;
         }

--- a/PowerSync/PowerSync.Common/PowerSync.Common.csproj
+++ b/PowerSync/PowerSync.Common/PowerSync.Common.csproj
@@ -35,7 +35,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
-    <PackageReference Include="ThrottleDebounce" Version="2.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/PowerSync/PowerSync.Common.Tests/Client/PowerSyncDatabaseTests.cs
+++ b/Tests/PowerSync/PowerSync.Common.Tests/Client/PowerSyncDatabaseTests.cs
@@ -678,6 +678,7 @@ public class PowerSyncDatabaseTests : IAsyncLifetime
             },
             Schema = TestSchema.MakeOptionalSyncSchema(false)
         });
+        await db.Init();
 
         try
         {

--- a/Tests/PowerSync/PowerSync.Common.Tests/Client/PowerSyncDatabaseTests.cs
+++ b/Tests/PowerSync/PowerSync.Common.Tests/Client/PowerSyncDatabaseTests.cs
@@ -1,10 +1,12 @@
 namespace PowerSync.Common.Tests.Client;
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
 
 using Microsoft.Data.Sqlite;
 
 using PowerSync.Common.Client;
+using PowerSync.Common.DB.Schema;
 using PowerSync.Common.Tests.Models;
 using PowerSync.Common.Tests.Utils;
 
@@ -1046,6 +1048,55 @@ public class PowerSyncDatabaseTests : IAsyncLifetime
         Assert.True(await tcs.Task);
         // The flush-on-cancel should still deliver the accumulated event
         Assert.Equal(1, eventCount);
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task OnChange_SchemaChangeDoesNotEmitEvent()
+    {
+        var events = new ConcurrentQueue<WatchOnChangeEvent>();
+        using var sem = new SemaphoreSlim(0);
+
+        var listener = db.OnChange(new SQLWatchOptions
+        {
+            Tables = ["assets"],
+            Signal = testCts.Token,
+        });
+
+        _ = Task.Run(async () =>
+        {
+            await foreach (var change in listener)
+            {
+                events.Enqueue(change);
+                sem.Release();
+            }
+        }, testCts.Token);
+
+        // Replace the schema without modifying the watched table.
+        await db.UpdateSchema(new Schema(
+            TestSchema.Assets,
+            new Table
+            {
+                Name = "customers",
+                Columns =
+                {
+                    ["name"] = ColumnType.Text,
+                    ["email"] = ColumnType.Text,
+                    ["phone"] = ColumnType.Text,
+                }
+            }));
+
+        // A schema change by itself shouldn't fire an OnChange event, since that would lead to empty events
+        // in the case of no underlying data update.
+        Assert.False(await sem.WaitAsync(300));
+        Assert.Empty(events);
+
+        // Real changes must still be reported after the schema change.
+        await TestUtils.InsertRandomAsset(db);
+
+        Assert.True(await sem.WaitAsync(500));
+        Assert.Single(events);
+        Assert.True(events.TryDequeue(out var change));
+        Assert.Equal(["assets"], change.ChangedTables);
     }
 
     [Fact]


### PR DESCRIPTION
Adds a `WatchManager` class that manages watched queries, replacing the in-class implementation in PowerSyncDatabase. The old code for watches was difficult to reason about and contained a lot of monkey-patching to support async iterators and schema resets triggering interruptions. This new approach moves all the logic into a dedicated `WatchManager` class which manages the watch subscription lifecycle and is designed from the ground up with async iterator support and schema resets in mind.

### Main differences

- `PowerSyncDatabase.Watch` / `PowerSyncDatabase.OnChange` are now wrappers around `WatchManager` methods.
- `SchemaChanged` event is no longer emitted on DB initialization (subject to change).
- `WatchManager` maintains one `TablesUpdated` event listener which is shared across multiple watches.

Also fixes a bug in the Watch_SchemaReset test where DB initialisation was not awaited, causing the test to frequently time out on the `windows-11-arm` runner.

## AI Usage

I blocked out the WatchManager and WatchSubscription classes and wired them up to PowerSyncDatabase and implemented the plumbing methods for WatchManager (Stream, RequestRefresh, CreateSubscription, etc.). I then asked Fable 5 to implement the watch logic using the old code as a reference and edited the results manually to fix some small errors and styling mistakes.