### PR TITLE
Simplify control flow in sync iteration

### DIFF
--- a/PowerSync/PowerSync.Common/CHANGELOG.md
+++ b/PowerSync/PowerSync.Common/CHANGELOG.md
@@ -1,5 +1,8 @@
 # PowerSync.Common Changelog
 
+## 0.1.4 (Unreleased)
+- Fix "No iteration is active" errors when a sync iteration ends
+
 ## 0.1.3
 
 - **Breaking:** Made `Table.Name` non-nullable (default ""). This change may affect 0% of users, but it is technically a breaking change.

--- a/PowerSync/PowerSync.Common/CHANGELOG.md
+++ b/PowerSync/PowerSync.Common/CHANGELOG.md
@@ -1,6 +1,7 @@
 # PowerSync.Common Changelog
 
 ## 0.1.4 (Unreleased)
+
 - Fix "No iteration is active" errors when a sync iteration ends
 
 ## 0.1.3

--- a/PowerSync/PowerSync.Common/Client/Sync/Bucket/BucketStorageAdapter.cs
+++ b/PowerSync/PowerSync.Common/Client/Sync/Bucket/BucketStorageAdapter.cs
@@ -18,6 +18,17 @@ public static class PowerSyncControlCommand
     public const string NOTIFY_TOKEN_REFRESHED = "refreshed_token";
     public const string NOTIFY_CRUD_UPLOAD_COMPLETED = "completed_upload";
     public const string UPDATE_SUBSCRIPTIONS = "update_subscriptions";
+
+    /// <summary>
+    /// An `established` or `end` event for response streams.
+    /// </summary>
+    public const string CONNECTION_STATE = "connection";
+}
+
+public static class PowerSyncControlConnectionState
+{
+    public const string ESTABLISHED = "established";
+    public const string END = "end";
 }
 
 public class Checkpoint

--- a/PowerSync/PowerSync.Common/Client/Sync/Stream/CoreInstructions.cs
+++ b/PowerSync/PowerSync.Common/Client/Sync/Stream/CoreInstructions.cs
@@ -11,15 +11,6 @@ namespace PowerSync.Common.Client.Sync.Stream;
 /// </summary>
 public abstract class Instruction
 {
-    /// <summary>
-    /// Whether this instruction starts or stops a sync iteration
-    /// (<see cref="EstablishSyncStream"/> or <see cref="CloseSyncStream"/>).
-    /// Interrupting instructions are handled by the iteration control loop; all
-    /// other (non-interrupting) instructions are handled by
-    /// <c>HandleInstruction</c>.
-    /// </summary>
-    public virtual bool IsInterrupting => false;
-
     public static Instruction[] ParseInstructions(string rawResponse)
     {
         var jsonArray = JArray.Parse(rawResponse);
@@ -59,7 +50,12 @@ public abstract class Instruction
     }
 }
 
-public class LogLine : Instruction
+/// <summary>
+/// An <see cref="Instruction"/> that doesn't start or stop a sync iteration.
+/// </summary>
+public abstract class NonInterruptingInstruction : Instruction { }
+
+public class LogLine : NonInterruptingInstruction
 {
     [JsonProperty("severity")]
     public string Severity { get; set; } = null!;  // "DEBUG", "INFO", "WARNING"
@@ -70,13 +66,11 @@ public class LogLine : Instruction
 
 public class EstablishSyncStream : Instruction
 {
-    public override bool IsInterrupting => true;
-
     [JsonProperty("request")]
     public StreamingSyncRequest Request { get; set; } = null!;
 }
 
-public class UpdateSyncStatus : Instruction
+public class UpdateSyncStatus : NonInterruptingInstruction
 {
     [JsonProperty("status")]
     public CoreSyncStatus Status { get; set; } = null!;
@@ -177,7 +171,7 @@ public class BucketProgress
     public int TargetCount { get; set; }
 }
 
-public class FetchCredentials : Instruction
+public class FetchCredentials : NonInterruptingInstruction
 {
     [JsonProperty("did_expire")]
     public bool DidExpire { get; set; }
@@ -185,14 +179,12 @@ public class FetchCredentials : Instruction
 
 public class CloseSyncStream : Instruction
 {
-    public override bool IsInterrupting => true;
-
     [JsonProperty("hide_disconnect")]
     public bool HideDisconnect { get; set; }
 }
 
-public class FlushFileSystem : Instruction { }
-public class DidCompleteSync : Instruction { }
+public class FlushFileSystem : NonInterruptingInstruction { }
+public class DidCompleteSync : NonInterruptingInstruction { }
 
 public class CoreInstructionHelpers
 {

--- a/PowerSync/PowerSync.Common/Client/Sync/Stream/CoreInstructions.cs
+++ b/PowerSync/PowerSync.Common/Client/Sync/Stream/CoreInstructions.cs
@@ -11,6 +11,14 @@ namespace PowerSync.Common.Client.Sync.Stream;
 /// </summary>
 public abstract class Instruction
 {
+    /// <summary>
+    /// Whether this instruction starts or stops a sync iteration
+    /// (<see cref="EstablishSyncStream"/> or <see cref="CloseSyncStream"/>).
+    /// Interrupting instructions are handled by the iteration control loop; all
+    /// other (non-interrupting) instructions are handled by
+    /// <c>HandleInstruction</c>.
+    /// </summary>
+    public virtual bool IsInterrupting => false;
 
     public static Instruction[] ParseInstructions(string rawResponse)
     {
@@ -62,6 +70,8 @@ public class LogLine : Instruction
 
 public class EstablishSyncStream : Instruction
 {
+    public override bool IsInterrupting => true;
+
     [JsonProperty("request")]
     public StreamingSyncRequest Request { get; set; } = null!;
 }
@@ -175,6 +185,8 @@ public class FetchCredentials : Instruction
 
 public class CloseSyncStream : Instruction
 {
+    public override bool IsInterrupting => true;
+
     [JsonProperty("hide_disconnect")]
     public bool HideDisconnect { get; set; }
 }

--- a/PowerSync/PowerSync.Common/Client/Sync/Stream/CoreInstructions.cs
+++ b/PowerSync/PowerSync.Common/Client/Sync/Stream/CoreInstructions.cs
@@ -40,7 +40,7 @@ public abstract class Instruction
         if (json.ContainsKey("FetchCredentials"))
             return json["FetchCredentials"]!.ToObject<FetchCredentials>();
         if (json.ContainsKey("CloseSyncStream"))
-            return new CloseSyncStream();
+            return json["CloseSyncStream"]!.ToObject<CloseSyncStream>();
         if (json.ContainsKey("FlushFileSystem"))
             return new FlushFileSystem();
         if (json.ContainsKey("DidCompleteSync"))

--- a/PowerSync/PowerSync.Common/Client/Sync/Stream/StreamingSyncImplementation.cs
+++ b/PowerSync/PowerSync.Common/Client/Sync/Stream/StreamingSyncImplementation.cs
@@ -659,12 +659,53 @@ public class StreamingSyncImplementation : ICloseable
             };
 
             StreamingSyncRequest? establishRequest = null;
+            IAsyncEnumerable<EnqueuedCommand>? commands = null;
+
             foreach (var startInstruction in await InvokePowerSyncControl(PowerSyncControlCommand.START, JsonConvert.SerializeObject(options)))
             {
                 if (startInstruction is EstablishSyncStream establish)
                 {
-                    controlInvocations = new EventStream<EnqueuedCommand>();
+                    var invocations = new EventStream<EnqueuedCommand>();
+                    controlInvocations = invocations;
                     establishRequest = establish.Request;
+
+                    // Subscribe before anything can emit, else the (possibly synchronous)
+                    // "established" event is lost.
+                    commands = invocations.ListenAsync(nestedCts.Token);
+
+                    // Wired up here rather than after this loop: a later instruction in this
+                    // same batch (FetchCredentials) already needs to enqueue a command.
+                    notifyCompletedUploads = () =>
+                    {
+                        if (!invocations.Closed)
+                        {
+                            invocations.Emit(new EnqueuedCommand
+                            {
+                                Command = PowerSyncControlCommand.NOTIFY_CRUD_UPLOAD_COMPLETED
+                            });
+                        }
+                    };
+                    handleActiveStreamsChange = () =>
+                    {
+                        if (!invocations.Closed)
+                        {
+                            invocations.Emit(new EnqueuedCommand
+                            {
+                                Command = PowerSyncControlCommand.UPDATE_SUBSCRIPTIONS,
+                                Payload = JsonConvert.SerializeObject(activeStreams)
+                            });
+                        }
+                    };
+                    notifyTokenRefreshed = () =>
+                    {
+                        if (!invocations.Closed)
+                        {
+                            invocations.Emit(new EnqueuedCommand
+                            {
+                                Command = PowerSyncControlCommand.NOTIFY_TOKEN_REFRESHED
+                            });
+                        }
+                    };
                 }
                 else if (startInstruction is CloseSyncStream)
                 {
@@ -681,49 +722,12 @@ public class StreamingSyncImplementation : ICloseable
                 return new StreamingSyncIterationResult { ImmediateRestart = false };
             }
 
-            var invocations = controlInvocations;
-
-            // Subscribe before reading starts, else the (possibly synchronous) "established"
-            // event is lost.
-            var commands = invocations.ListenAsync(nestedCts.Token);
-            receivingLines = ReceiveSyncLines(establishRequest!, invocations, nestedCts.Token);
-
-            notifyCompletedUploads = () =>
-            {
-                if (!invocations.Closed)
-                {
-                    invocations.Emit(new EnqueuedCommand
-                    {
-                        Command = PowerSyncControlCommand.NOTIFY_CRUD_UPLOAD_COMPLETED
-                    });
-                }
-            };
-            handleActiveStreamsChange = () =>
-            {
-                if (!invocations.Closed)
-                {
-                    invocations.Emit(new EnqueuedCommand
-                    {
-                        Command = PowerSyncControlCommand.UPDATE_SUBSCRIPTIONS,
-                        Payload = JsonConvert.SerializeObject(activeStreams)
-                    });
-                }
-            };
-            notifyTokenRefreshed = () =>
-            {
-                if (!invocations.Closed)
-                {
-                    invocations.Emit(new EnqueuedCommand
-                    {
-                        Command = PowerSyncControlCommand.NOTIFY_TOKEN_REFRESHED
-                    });
-                }
-            };
+            receivingLines = ReceiveSyncLines(establishRequest!, controlInvocations, nestedCts.Token);
 
             var hadSyncLine = false;
             try
             {
-                await foreach (var command in commands)
+                await foreach (var command in commands!)
                 {
                     var close = false;
                     foreach (var instruction in await InvokePowerSyncControl(command.Command, command.Payload))

--- a/PowerSync/PowerSync.Common/Client/Sync/Stream/StreamingSyncImplementation.cs
+++ b/PowerSync/PowerSync.Common/Client/Sync/Stream/StreamingSyncImplementation.cs
@@ -528,7 +528,11 @@ public class StreamingSyncImplementation : ICloseable
 
                     if (completedTask == cancellationTcs.Task)
                     {
-                        // Cancellation was requested, exit the loop
+                        // Cancellation was requested, exit the loop. The read is still in
+                        // flight and faults once the stream is closed during teardown, so
+                        // observe it to keep that failure out of
+                        // TaskScheduler.UnobservedTaskException.
+                        _ = readTask.ContinueWith(t => { _ = t.Exception; }, TaskContinuationOptions.OnlyOnFaulted);
                         break;
                     }
 

--- a/PowerSync/PowerSync.Common/Client/Sync/Stream/StreamingSyncImplementation.cs
+++ b/PowerSync/PowerSync.Common/Client/Sync/Stream/StreamingSyncImplementation.cs
@@ -734,7 +734,7 @@ public class StreamingSyncImplementation : ICloseable
                     {
                         if (instruction is EstablishSyncStream)
                         {
-                            throw new Exception("Received EstablishSyncStream while already connected.");
+                            throw new InvalidOperationException("Received EstablishSyncStream while already connected.");
                         }
                         if (instruction is CloseSyncStream closeSyncStream)
                         {

--- a/PowerSync/PowerSync.Common/Client/Sync/Stream/StreamingSyncImplementation.cs
+++ b/PowerSync/PowerSync.Common/Client/Sync/Stream/StreamingSyncImplementation.cs
@@ -476,66 +476,53 @@ public class StreamingSyncImplementation : ICloseable
 
     protected async Task<StreamingSyncIterationResult> RustStreamingSyncIteration(CancellationToken? signal, RequiredPowerSyncConnectionOptions resolvedOptions)
     {
-        Task? receivingLines = null;
-        bool hadSyncLine = false;
         bool hideDisconnectOnRestart = false;
+        Action? notifyTokenRefreshed = null;
 
-        var controlInvocations = (EventStream<EnqueuedCommand>)null!;
+        // A failure opening or reading the stream, surfaced from the control loop so it retries.
+        Exception? streamError = null;
 
         var nestedCts = new CancellationTokenSource();
         signal?.Register(() => { nestedCts.Cancel(); });
 
-        async Task Connect(EstablishSyncStream instruction)
+        async Task ReceiveSyncLines(StreamingSyncRequest request, EventStream<EnqueuedCommand> sink, CancellationToken token)
         {
             var syncOptions = new SyncStreamOptions
             {
                 Path = "/sync/stream",
-                CancellationToken = nestedCts.Token,
-                Data = instruction.Request
+                CancellationToken = token,
+                Data = request
             };
 
-            controlInvocations = new EventStream<EnqueuedCommand>();
+            var established = false;
             try
             {
-                _ = Task.Run(async () =>
-                {
-                    await foreach (var line in controlInvocations.ListenAsync(new CancellationToken()))
-                    {
-                        await Control(line.Command, line.Payload);
-
-                        // Triggers a local CRUD upload when the first sync line has been received.
-                        // This allows uploading local changes that have been made while offline or disconnected.
-                        if (!hadSyncLine)
-                        {
-                            TriggerCrudUpload();
-                            hadSyncLine = true;
-                        }
-                    }
-                });
-
                 var stream = await Options.Remote.PostStreamRaw(syncOptions);
                 using var reader = new StreamReader(stream, Encoding.UTF8);
 
-                syncOptions.CancellationToken.Register(() =>
+                token.Register(() =>
                 {
                     try { stream?.Close(); } catch { }
                 });
 
-                UpdateSyncStatus(new SyncStatusOptions
+                // We're connected here, tell core extension
+                sink.Emit(new EnqueuedCommand
                 {
-                    Connected = true
+                    Command = PowerSyncControlCommand.CONNECTION_STATE,
+                    Payload = PowerSyncControlConnectionState.ESTABLISHED
                 });
+                established = true;
 
                 // Read lines in a cancellation-aware manner.
                 // ReadLineAsync() doesn't support CancellationToken on all .NET versions,
                 // so we use WhenAny to check for cancellation between reads.
-                while (!syncOptions.CancellationToken.IsCancellationRequested)
+                while (!token.IsCancellationRequested)
                 {
                     var readTask = reader.ReadLineAsync();
 
                     // Create a task that completes when cancellation is requested
                     var cancellationTcs = new TaskCompletionSource<bool>();
-                    using var registration = syncOptions.CancellationToken.Register(() => cancellationTcs.TrySetResult(true));
+                    using var registration = token.Register(() => cancellationTcs.TrySetResult(true));
 
                     var completedTask = await Task.WhenAny(readTask, cancellationTcs.Task);
 
@@ -552,39 +539,53 @@ public class StreamingSyncImplementation : ICloseable
                         break;
                     }
 
-                    controlInvocations?.Emit(new EnqueuedCommand
+                    sink.Emit(new EnqueuedCommand
                     {
                         Command = PowerSyncControlCommand.PROCESS_TEXT_LINE,
                         Payload = line
                     });
                 }
             }
+            catch (Exception ex)
+            {
+                if (!token.IsCancellationRequested)
+                {
+                    streamError = ex;
+                }
+            }
             finally
             {
-                var activeInstructions = controlInvocations;
-                controlInvocations = null;
-                activeInstructions?.Close();
+                if (established && !sink.Closed)
+                {
+                    sink.Emit(new EnqueuedCommand
+                    {
+                        Command = PowerSyncControlCommand.CONNECTION_STATE,
+                        Payload = PowerSyncControlConnectionState.END
+                    });
+                }
+
+                sink.Close();
             }
         }
 
         async Task Stop()
         {
-            await Control(PowerSyncControlCommand.STOP);
+            foreach (var instruction in await InvokePowerSyncControl(PowerSyncControlCommand.STOP))
+            {
+                // Unconditionally ending the iteration, so interrupting instructions don't apply.
+                if (instruction.IsInterrupting)
+                {
+                    continue;
+                }
+                await HandleInstruction(instruction);
+            }
         }
 
-        async Task Control(string op, object? payload = null)
+        async Task<Instruction[]> InvokePowerSyncControl(string op, object? payload = null)
         {
             var rawResponse = await Options.Adapter.Control(op, payload);
             logger.LogTrace("powersync_control {op}, {payload}, {rawResponse}", op, payload, rawResponse);
-            HandleInstructions(Instruction.ParseInstructions(rawResponse));
-        }
-
-        async void HandleInstructions(Instruction[] instructions)
-        {
-            foreach (var instruction in instructions)
-            {
-                await HandleInstruction(instruction);
-            }
+            return Instruction.ParseInstructions(rawResponse);
         }
 
         async Task HandleInstruction(Instruction instruction)
@@ -608,14 +609,6 @@ public class StreamingSyncImplementation : ICloseable
                 case UpdateSyncStatus syncStatus:
                     UpdateSyncStatus(CoreInstructionHelpers.CoreStatusToSyncStatusOptions(syncStatus.Status));
                     break;
-                case EstablishSyncStream establishSyncStream:
-                    if (receivingLines != null)
-                    {
-                        throw new Exception("Unexpected request to establish sync stream, already connected");
-                    }
-
-                    receivingLines = Connect(establishSyncStream);
-                    break;
                 case FetchCredentials fetchCredentials:
                     if (fetchCredentials.DidExpire)
                     {
@@ -629,10 +622,7 @@ public class StreamingSyncImplementation : ICloseable
                         try
                         {
                             await Options.Remote.FetchCredentials();
-                            controlInvocations?.Emit(new EnqueuedCommand
-                            {
-                                Command = PowerSyncControlCommand.NOTIFY_TOKEN_REFRESHED
-                            });
+                            notifyTokenRefreshed?.Invoke();
                         }
                         catch (Exception err)
                         {
@@ -640,11 +630,6 @@ public class StreamingSyncImplementation : ICloseable
                         }
 
                     }
-                    break;
-                case CloseSyncStream closeSyncStream:
-                    nestedCts.Cancel();
-                    hideDisconnectOnRestart = closeSyncStream.HideDisconnect;
-                    logger.LogWarning("Closing stream");
                     break;
                 case FlushFileSystem:
                     // ignore
@@ -657,6 +642,9 @@ public class StreamingSyncImplementation : ICloseable
             }
         }
 
+        EventStream<EnqueuedCommand>? controlInvocations = null;
+        Task? receivingLines = null;
+
         try
         {
             var options = new
@@ -666,43 +654,131 @@ public class StreamingSyncImplementation : ICloseable
                 include_defaults = resolvedOptions.IncludeDefaultStreams,
                 app_metadata = resolvedOptions.AppMetadata
             };
-            await Control(PowerSyncControlCommand.START, JsonConvert.SerializeObject(options));
+
+            StreamingSyncRequest? establishRequest = null;
+            foreach (var startInstruction in await InvokePowerSyncControl(PowerSyncControlCommand.START, JsonConvert.SerializeObject(options)))
+            {
+                if (startInstruction is EstablishSyncStream establish)
+                {
+                    controlInvocations = new EventStream<EnqueuedCommand>();
+                    establishRequest = establish.Request;
+                }
+                else if (startInstruction is CloseSyncStream)
+                {
+                    return new StreamingSyncIterationResult { ImmediateRestart = false };
+                }
+                else
+                {
+                    await HandleInstruction(startInstruction);
+                }
+            }
+
+            if (controlInvocations == null)
+            {
+                return new StreamingSyncIterationResult { ImmediateRestart = false };
+            }
+
+            var invocations = controlInvocations;
+
+            // Subscribe before reading starts, else the (possibly synchronous) "established"
+            // event is lost.
+            var commands = invocations.ListenAsync(nestedCts.Token);
+            receivingLines = ReceiveSyncLines(establishRequest!, invocations, nestedCts.Token);
 
             notifyCompletedUploads = () =>
             {
-                Task.Run(() =>
+                if (!invocations.Closed)
                 {
-                    if (controlInvocations != null && !controlInvocations.Closed)
+                    invocations.Emit(new EnqueuedCommand
                     {
-                        controlInvocations?.Emit(new EnqueuedCommand
-                        {
-                            Command = PowerSyncControlCommand.NOTIFY_CRUD_UPLOAD_COMPLETED
-                        });
-                    }
-                });
+                        Command = PowerSyncControlCommand.NOTIFY_CRUD_UPLOAD_COMPLETED
+                    });
+                }
             };
-
             handleActiveStreamsChange = () =>
             {
-                if (controlInvocations != null && !controlInvocations.Closed)
+                if (!invocations.Closed)
                 {
-                    controlInvocations?.Emit(new EnqueuedCommand
+                    invocations.Emit(new EnqueuedCommand
                     {
                         Command = PowerSyncControlCommand.UPDATE_SUBSCRIPTIONS,
                         Payload = JsonConvert.SerializeObject(activeStreams)
                     });
                 }
             };
-
-            if (receivingLines != null)
+            notifyTokenRefreshed = () =>
             {
-                await receivingLines;
+                if (!invocations.Closed)
+                {
+                    invocations.Emit(new EnqueuedCommand
+                    {
+                        Command = PowerSyncControlCommand.NOTIFY_TOKEN_REFRESHED
+                    });
+                }
+            };
+
+            var hadSyncLine = false;
+            try
+            {
+                await foreach (var command in commands)
+                {
+                    var close = false;
+                    foreach (var instruction in await InvokePowerSyncControl(command.Command, command.Payload))
+                    {
+                        if (instruction is EstablishSyncStream)
+                        {
+                            throw new Exception("Received EstablishSyncStream while already connected.");
+                        }
+                        if (instruction is CloseSyncStream closeSyncStream)
+                        {
+                            hideDisconnectOnRestart = closeSyncStream.HideDisconnect;
+                            logger.LogWarning("Closing stream");
+                            close = true;
+                            break;
+                        }
+                        await HandleInstruction(instruction);
+                    }
+
+                    if (!hadSyncLine &&
+                        (command.Command == PowerSyncControlCommand.PROCESS_TEXT_LINE ||
+                         command.Command == PowerSyncControlCommand.PROCESS_BSON_LINE))
+                    {
+                        // Triggers a local CRUD upload when the first sync line has been received.
+                        // This allows uploading local changes that have been made while offline or disconnected.
+                        hadSyncLine = true;
+                        TriggerCrudUpload();
+                    }
+
+                    if (close)
+                    {
+                        break;
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (nestedCts.IsCancellationRequested)
+            {
+                // Disconnect/abort, stop consuming
+            }
+
+            if (streamError != null)
+            {
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(streamError).Throw();
             }
         }
         finally
         {
             notifyCompletedUploads = null;
             handleActiveStreamsChange = null;
+            notifyTokenRefreshed = null;
+
+            nestedCts.Cancel();
+            controlInvocations?.Close();
+
+            if (receivingLines != null)
+            {
+                try { await receivingLines; } catch { /* surfaced via streamError */ }
+            }
+
             await Stop();
         }
 

--- a/PowerSync/PowerSync.Common/Client/Sync/Stream/StreamingSyncImplementation.cs
+++ b/PowerSync/PowerSync.Common/Client/Sync/Stream/StreamingSyncImplementation.cs
@@ -573,11 +573,10 @@ public class StreamingSyncImplementation : ICloseable
             foreach (var instruction in await InvokePowerSyncControl(PowerSyncControlCommand.STOP))
             {
                 // Unconditionally ending the iteration, so interrupting instructions don't apply.
-                if (instruction.IsInterrupting)
+                if (instruction is NonInterruptingInstruction nonInterrupting)
                 {
-                    continue;
+                    await HandleInstruction(nonInterrupting);
                 }
-                await HandleInstruction(instruction);
             }
         }
 
@@ -588,7 +587,7 @@ public class StreamingSyncImplementation : ICloseable
             return Instruction.ParseInstructions(rawResponse);
         }
 
-        async Task HandleInstruction(Instruction instruction)
+        async Task HandleInstruction(NonInterruptingInstruction instruction)
         {
             switch (instruction)
             {
@@ -667,9 +666,9 @@ public class StreamingSyncImplementation : ICloseable
                 {
                     return new StreamingSyncIterationResult { ImmediateRestart = false };
                 }
-                else
+                else if (startInstruction is NonInterruptingInstruction nonInterrupting)
                 {
-                    await HandleInstruction(startInstruction);
+                    await HandleInstruction(nonInterrupting);
                 }
             }
 
@@ -736,7 +735,10 @@ public class StreamingSyncImplementation : ICloseable
                             close = true;
                             break;
                         }
-                        await HandleInstruction(instruction);
+                        if (instruction is NonInterruptingInstruction nonInterrupting)
+                        {
+                            await HandleInstruction(nonInterrupting);
+                        }
                     }
 
                     if (!hadSyncLine &&

--- a/PowerSync/PowerSync.Maui/CHANGELOG.md
+++ b/PowerSync/PowerSync.Maui/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PowerSync.Maui Changelog
 
+## 0.1.4 (Unreleased)
+
+- Upstream PowerSync.Common version bump (See Powersync.Common changelog 0.1.4 for more information)
+
 ## 0.1.3
 
 - Upstream PowerSync.Common version bump (See Powersync.Common changelog 0.1.3 for more information)

--- a/Tests/PowerSync/PowerSync.Common.Tests/Client/Sync/SyncIterationControlFlowTests.cs
+++ b/Tests/PowerSync/PowerSync.Common.Tests/Client/Sync/SyncIterationControlFlowTests.cs
@@ -82,9 +82,7 @@ public class SyncIterationControlFlowTests
 
     /// <summary>
     /// When START asks for credentials, the refreshed token must still be
-    /// reported back to the core. `notifyTokenRefreshed` is only assigned after
-    /// the START instruction batch has been handled, so an awaited refresh
-    /// inside that batch drops the notification.
+    /// reported back to the core.
     /// Surfaces when the cached token is stale at connect time, e.g. resume from background.
     /// </summary>
     [Fact(Timeout = 15000)]

--- a/Tests/PowerSync/PowerSync.Common.Tests/Client/Sync/SyncIterationControlFlowTests.cs
+++ b/Tests/PowerSync/PowerSync.Common.Tests/Client/Sync/SyncIterationControlFlowTests.cs
@@ -20,6 +20,7 @@ public class SyncIterationControlFlowTests
 {
     private const string EstablishOnly = @"[{""EstablishSyncStream"":{""request"":{}}}]";
     private const string NoInstructions = "[]";
+    private const string CloseWithoutHidingDisconnect = @"[{""CloseSyncStream"":{""hide_disconnect"":false}}]";
 
     /// <summary>
     /// A read failure while the stream is open must reach the outer retry loop,
@@ -149,7 +150,7 @@ public class SyncIterationControlFlowTests
                 PowerSyncControlCommand.START => EstablishOnly,
                 // The core closes the stream on the first line, leaving the next
                 // ReadLineAsync in flight.
-                PowerSyncControlCommand.PROCESS_TEXT_LINE => @"[{""CloseSyncStream"":{""hide_disconnect"":false}}]",
+                PowerSyncControlCommand.PROCESS_TEXT_LINE => CloseWithoutHidingDisconnect,
                 _ => NoInstructions
             });
 

--- a/Tests/PowerSync/PowerSync.Common.Tests/Client/Sync/SyncIterationControlFlowTests.cs
+++ b/Tests/PowerSync/PowerSync.Common.Tests/Client/Sync/SyncIterationControlFlowTests.cs
@@ -1,0 +1,366 @@
+namespace PowerSync.Common.Tests.Client.Sync;
+
+using System.Collections.Concurrent;
+using System.Text;
+
+using PowerSync.Common.Client;
+using PowerSync.Common.Client.Connection;
+using PowerSync.Common.Client.Sync.Bucket;
+using PowerSync.Common.Client.Sync.Stream;
+using PowerSync.Common.DB.Crud;
+
+/// <summary>
+/// Drives a single sync iteration against a scripted core extension so the
+/// client's control flow can be asserted without a real powersync_control.
+///
+/// dotnet test -v n --framework net8.0 --filter "SyncIterationControlFlowTests"
+/// </summary>
+[Collection("SyncIterationControlFlowTests")]
+public class SyncIterationControlFlowTests
+{
+    private const string EstablishOnly = @"[{""EstablishSyncStream"":{""request"":{}}}]";
+    private const string NoInstructions = "[]";
+
+    /// <summary>
+    /// A read failure while the stream is open must reach the outer retry loop,
+    /// and the core must be told the connection ended before the iteration stops.
+    /// Surfaces when the socket dies mid-sync: Wi-Fi drop, cell handover, or an idle proxy timeout.
+    /// </summary>
+    [Fact(Timeout = 15000)]
+    public async Task MidStreamReadFailureIsSurfacedToRetryLoop()
+    {
+        var sentinel = $"read-failed-{Guid.NewGuid():N}";
+        var adapter = new ScriptedAdapter((op, _) => op switch
+        {
+            PowerSyncControlCommand.START => EstablishOnly,
+            _ => NoInstructions
+        });
+
+        // One line, then the socket dies.
+        var harness = Harness.Create(adapter, _ => Task.FromResult<Stream>(
+            new FailAfterPrefixStream("{}\n", new IOException(sentinel))));
+
+        var thrown = await Assert.ThrowsAsync<IOException>(() => harness.RunIteration());
+
+        Assert.Equal(sentinel, thrown.Message);
+        Assert.Equal(
+            new[]
+            {
+                PowerSyncControlCommand.START,
+                PowerSyncControlCommand.CONNECTION_STATE,   // established
+                PowerSyncControlCommand.PROCESS_TEXT_LINE,
+                PowerSyncControlCommand.CONNECTION_STATE,   // end
+                PowerSyncControlCommand.STOP
+            },
+            adapter.Ops);
+    }
+
+    /// <summary>
+    /// A failure opening the stream must also reach the retry loop, and the
+    /// iteration must still stop the core's iteration on the way out.
+    /// Surfaces when the connect POST fails: offline, DNS failure, or a 401 from an expired token.
+    /// </summary>
+    [Fact(Timeout = 15000)]
+    public async Task StreamOpenFailureIsSurfacedToRetryLoop()
+    {
+        var sentinel = $"open-failed-{Guid.NewGuid():N}";
+        var adapter = new ScriptedAdapter((op, _) => op switch
+        {
+            PowerSyncControlCommand.START => EstablishOnly,
+            _ => NoInstructions
+        });
+
+        var harness = Harness.Create(adapter,
+            _ => Task.FromException<Stream>(new HttpRequestException(sentinel)));
+
+        var thrown = await Assert.ThrowsAsync<HttpRequestException>(() => harness.RunIteration());
+
+        Assert.Equal(sentinel, thrown.Message);
+        // No "established"/"end" - the stream never opened.
+        Assert.Equal(new[] { PowerSyncControlCommand.START, PowerSyncControlCommand.STOP }, adapter.Ops);
+    }
+
+    /// <summary>
+    /// When START asks for credentials, the refreshed token must still be
+    /// reported back to the core. `notifyTokenRefreshed` is only assigned after
+    /// the START instruction batch has been handled, so an awaited refresh
+    /// inside that batch drops the notification.
+    /// Surfaces when the cached token is stale at connect time, e.g. resume from background.
+    /// </summary>
+    [Fact(Timeout = 15000)]
+    public async Task TokenRefreshedDuringStartIsForwardedToCore()
+    {
+        var refreshed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var adapter = new ScriptedAdapter((op, _) =>
+        {
+            switch (op)
+            {
+                case PowerSyncControlCommand.START:
+                    // The core wants a fresh token before it will accept sync lines.
+                    return @"[{""EstablishSyncStream"":{""request"":{}}},{""FetchCredentials"":{""did_expire"":false}}]";
+                case PowerSyncControlCommand.NOTIFY_TOKEN_REFRESHED:
+                    refreshed.TrySetResult(true);
+                    return NoInstructions;
+                default:
+                    return NoInstructions;
+            }
+        });
+
+        // Stream stays open so the control loop keeps consuming.
+        var harness = Harness.Create(adapter, _ => Task.FromResult<Stream>(new HangingStream("")));
+
+        var iteration = harness.RunIteration();
+        var forwarded = await Task.WhenAny(refreshed.Task, Task.Delay(3000)) == refreshed.Task;
+
+        harness.Cancel();
+        try { await iteration; } catch { /* teardown */ }
+
+        Assert.True(forwarded,
+            "Expected 'refreshed_token' to be forwarded to the core after the credential refresh " +
+            $"requested by START, but only saw: {string.Join(", ", adapter.Ops)}");
+    }
+
+    /// <summary>
+    /// Tearing down the stream reader must not leave the in-flight
+    /// ReadLineAsync task's exception unobserved - that is exactly the crash
+    /// reporting noise this control flow rework is meant to remove.
+    /// Surfaces on every teardown with a read in flight: any Disconnect, or a core-initiated close.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task AbandonedReadDoesNotLeakUnobservedException()
+    {
+        var sentinel = $"abandoned-read-{Guid.NewGuid():N}";
+        var unobserved = new ConcurrentBag<string>();
+        void Handler(object? sender, UnobservedTaskExceptionEventArgs e)
+        {
+            foreach (var ex in e.Exception.Flatten().InnerExceptions)
+            {
+                if (ex.Message.Contains(sentinel))
+                {
+                    unobserved.Add(ex.Message);
+                    e.SetObserved();
+                }
+            }
+        }
+
+        TaskScheduler.UnobservedTaskException += Handler;
+        try
+        {
+            var adapter = new ScriptedAdapter((op, _) => op switch
+            {
+                PowerSyncControlCommand.START => EstablishOnly,
+                // The core closes the stream on the first line, leaving the next
+                // ReadLineAsync in flight.
+                PowerSyncControlCommand.PROCESS_TEXT_LINE => @"[{""CloseSyncStream"":{""hide_disconnect"":false}}]",
+                _ => NoInstructions
+            });
+
+            // One line, then block until the stream is closed during teardown.
+            var harness = Harness.Create(adapter, _ => Task.FromResult<Stream>(
+                new HangingStream("{}\n", new IOException(sentinel))));
+
+            await harness.RunIteration();
+
+            // Unobserved exceptions are only raised when the task is finalized.
+            for (var i = 0; i < 5 && unobserved.IsEmpty; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                await Task.Delay(100);
+            }
+        }
+        finally
+        {
+            TaskScheduler.UnobservedTaskException -= Handler;
+        }
+
+        Assert.True(unobserved.IsEmpty,
+            $"The abandoned read faulted with {unobserved.Count} unobserved exception(s): " +
+            string.Join(", ", unobserved));
+    }
+
+    /// <summary>
+    /// `hide_disconnect` must survive parsing: it is what tells the outer loop
+    /// to restart immediately instead of waiting out the retry delay.
+    /// Surfaces whenever the core asks for a seamless restart: token refresh or subscription change.
+    /// </summary>
+    [Fact(Timeout = 15000)]
+    public async Task HideDisconnectRequestsImmediateRestart()
+    {
+        var adapter = new ScriptedAdapter((op, _) => op switch
+        {
+            PowerSyncControlCommand.START => EstablishOnly,
+            PowerSyncControlCommand.CONNECTION_STATE => @"[{""CloseSyncStream"":{""hide_disconnect"":true}}]",
+            _ => NoInstructions
+        });
+
+        var harness = Harness.Create(adapter, _ => Task.FromResult<Stream>(new HangingStream("")));
+
+        var immediateRestart = await harness.RunIteration();
+
+        Assert.True(immediateRestart,
+            "Expected CloseSyncStream(hide_disconnect: true) to request an immediate restart.");
+    }
+
+    // ---- harness -----------------------------------------------------------
+
+    private sealed class Harness
+    {
+        private readonly TestSyncImplementation sync;
+        private readonly CancellationTokenSource cts = new();
+
+        private Harness(TestSyncImplementation sync) => this.sync = sync;
+
+        public static Harness Create(ScriptedAdapter adapter, Func<SyncStreamOptions, Task<Stream>> openStream)
+        {
+            return new Harness(new TestSyncImplementation(new StreamingSyncImplementationOptions
+            {
+                Adapter = adapter,
+                Remote = new ScriptedRemote(new StaticConnector(), openStream),
+                Subscriptions = [],
+                UploadCrud = () => Task.CompletedTask
+            }));
+        }
+
+        public Task<bool?> RunIteration() => sync.RunIteration(cts.Token);
+
+        public void Cancel() => cts.Cancel();
+    }
+
+    /// <summary>Exposes the protected iteration so a single pass can be asserted.</summary>
+    private sealed class TestSyncImplementation(StreamingSyncImplementationOptions options)
+        : StreamingSyncImplementation(options)
+    {
+        public async Task<bool?> RunIteration(CancellationToken token)
+        {
+            var result = await RustStreamingSyncIteration(token, DEFAULT_STREAM_CONNECTION_OPTIONS);
+            return result.ImmediateRestart;
+        }
+    }
+
+    /// <summary>Records every powersync_control op and replies with canned instructions.</summary>
+    private sealed class ScriptedAdapter(Func<string, object?, string> respond) : IBucketStorageAdapter
+    {
+        private readonly ConcurrentQueue<string> ops = new();
+
+        public IEnumerable<string> Ops => ops;
+
+        public BucketStorageEvents Events { get; } = new();
+
+        public Task<string> Control(string op, object? payload)
+        {
+            ops.Enqueue(op);
+            return Task.FromResult(respond(op, payload));
+        }
+
+        public Task Init() => Task.CompletedTask;
+        public Task<CrudEntry?> NextCrudItem() => Task.FromResult<CrudEntry?>(null);
+        public Task<bool> HasCrud() => Task.FromResult(false);
+        public Task<CrudBatch?> GetCrudBatch(int limit = 100) => Task.FromResult<CrudBatch?>(null);
+        public Task<bool> HasCompletedSync() => Task.FromResult(false);
+        public Task<bool> UpdateLocalTarget(Func<Task<string>> callback) => Task.FromResult(false);
+        public string GetMaxOpId() => "9223372036854775807";
+        public Task<string> GetClientId() => Task.FromResult("test-client");
+        public void Close() { }
+    }
+
+    private sealed class ScriptedRemote(IPowerSyncBackendConnector connector, Func<SyncStreamOptions, Task<Stream>> open)
+        : Remote(connector)
+    {
+        public override Task<Stream> PostStreamRaw(SyncStreamOptions options) => open(options);
+    }
+
+    private sealed class StaticConnector : IPowerSyncBackendConnector
+    {
+        public Task<PowerSyncCredentials?> FetchCredentials() =>
+            Task.FromResult<PowerSyncCredentials?>(new PowerSyncCredentials("https://powersync.example.org", "test"));
+
+        public Task UploadData(IPowerSyncDatabase database) => Task.CompletedTask;
+    }
+
+    // ---- streams -----------------------------------------------------------
+
+    /// <summary>
+    /// Serves <paramref name="prefix"/>, then blocks. A pending read completes
+    /// with <paramref name="failWith"/> when the stream is closed, mimicking a
+    /// socket torn down underneath an in-flight read.
+    /// </summary>
+    private class HangingStream(string prefix, Exception? failWith = null) : Stream
+    {
+        private readonly byte[] head = Encoding.UTF8.GetBytes(prefix);
+        private readonly TaskCompletionSource<int> pending = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int offset;
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            var served = ServeHead(buffer.AsSpan(offset, count));
+            return served > 0 ? Task.FromResult(served) : ReadWhenDrained();
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            var served = ServeHead(buffer.Span);
+            return served > 0
+                ? new ValueTask<int>(served)
+                : new ValueTask<int>(ReadWhenDrained());
+        }
+
+        /// <summary>What a read does once the prefix has been consumed.</summary>
+        protected virtual Task<int> ReadWhenDrained() => pending.Task;
+
+        private int ServeHead(Span<byte> destination)
+        {
+            var remaining = head.Length - offset;
+            if (remaining <= 0)
+            {
+                return 0;
+            }
+
+            var count = Math.Min(remaining, destination.Length);
+            head.AsSpan(offset, count).CopyTo(destination);
+            offset += count;
+            return count;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            Unblock();
+            base.Dispose(disposing);
+        }
+
+        public override void Close()
+        {
+            Unblock();
+            base.Close();
+        }
+
+        private void Unblock()
+        {
+            if (failWith != null)
+            {
+                pending.TrySetException(failWith);
+            }
+            else
+            {
+                pending.TrySetResult(0);
+            }
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    /// <summary>Serves a prefix, then fails the next read immediately.</summary>
+    private sealed class FailAfterPrefixStream(string prefix, Exception failWith) : HangingStream(prefix)
+    {
+        protected override Task<int> ReadWhenDrained() => Task.FromException<int>(failWith);
+    }
+}

--- a/Tests/PowerSync/PowerSync.Common.Tests/Client/Sync/SyncIterationTeardownTests.cs
+++ b/Tests/PowerSync/PowerSync.Common.Tests/Client/Sync/SyncIterationTeardownTests.cs
@@ -2,8 +2,6 @@ namespace PowerSync.Common.Tests.Client.Sync;
 
 using System.Collections.Concurrent;
 
-using Newtonsoft.Json;
-
 using PowerSync.Common.Client;
 using PowerSync.Common.Tests.Utils;
 using PowerSync.Common.Tests.Utils.Sync;
@@ -11,13 +9,17 @@ using PowerSync.Common.Tests.Utils.Sync;
 /// <summary>
 /// Verifies how a sync iteration tears down: once an iteration has ended, no
 /// further control op is forwarded to the core. The core rejects control ops
-/// after its iteration stops (see <see cref="ControlOpAfterStopThrows"/>), so
-/// forwarding a queued op after teardown would surface an unhandled exception.
-/// The control loop must therefore stop forwarding as soon as the iteration
-/// closes.
+/// after its iteration stops ("No iteration is active"), so forwarding a queued
+/// op after teardown would surface an unhandled exception. The control loop must
+/// therefore stop forwarding as soon as the iteration closes.
+///
+/// This hooks the process-wide <see cref="TaskScheduler.UnobservedTaskException"/>,
+/// so it filters on the core's error message rather than asserting the bag is
+/// empty - other collections run in parallel and would otherwise bleed in.
 ///
 /// dotnet test -v n --framework net8.0 --filter "SyncIterationTeardownTests"
 /// </summary>
+[Collection("SyncIterationTeardownTests")]
 public class SyncIterationTeardownTests
 {
 
@@ -82,6 +84,4 @@ public class SyncIterationTeardownTests
         Assert.True(leaked.Count == 0,
             $"Expected no control ops forwarded after teardown, but {leaked.Count} 'No iteration is active' exceptions escaped.");
     }
-
-    private record ControlRow(string? r);
 }

--- a/Tests/PowerSync/PowerSync.Common.Tests/Client/Sync/SyncIterationTeardownTests.cs
+++ b/Tests/PowerSync/PowerSync.Common.Tests/Client/Sync/SyncIterationTeardownTests.cs
@@ -14,14 +14,17 @@ using PowerSync.Common.Tests.Utils.Sync;
 /// therefore stop forwarding as soon as the iteration closes.
 ///
 /// This hooks the process-wide <see cref="TaskScheduler.UnobservedTaskException"/>,
-/// so it filters on the core's error message rather than asserting the bag is
-/// empty - other collections run in parallel and would otherwise bleed in.
+/// so it only collects (and only observes) exceptions carrying the core's error
+/// message - other collections run in parallel, and claiming their exceptions
+/// would both bleed into this assertion and hide their own failures.
 ///
 /// dotnet test -v n --framework net8.0 --filter "SyncIterationTeardownTests"
 /// </summary>
 [Collection("SyncIterationTeardownTests")]
 public class SyncIterationTeardownTests
 {
+    /// <summary>What the core reports when a control op arrives after its iteration stopped.</summary>
+    private const string CoreIterationError = "No iteration is active";
 
     /// <summary>
     /// Disconnecting while sync lines are still queued must end the iteration
@@ -31,14 +34,17 @@ public class SyncIterationTeardownTests
     [Fact(Timeout = 60000)]
     public async Task DisconnectWithQueuedLinesEndsCleanly()
     {
-        var unobserved = new ConcurrentBag<string>();
+        var leaked = new ConcurrentBag<string>();
         void Handler(object? sender, UnobservedTaskExceptionEventArgs e)
         {
             foreach (var ex in e.Exception.Flatten().InnerExceptions)
             {
-                unobserved.Add(ex.Message);
+                if (ex.Message.Contains(CoreIterationError))
+                {
+                    leaked.Add(ex.Message);
+                    e.SetObserved();
+                }
             }
-            e.SetObserved();
         }
 
         TaskScheduler.UnobservedTaskException += Handler;
@@ -80,8 +86,7 @@ public class SyncIterationTeardownTests
             TaskScheduler.UnobservedTaskException -= Handler;
         }
 
-        var leaked = unobserved.Where(m => m.Contains("No iteration is active")).ToList();
-        Assert.True(leaked.Count == 0,
-            $"Expected no control ops forwarded after teardown, but {leaked.Count} 'No iteration is active' exceptions escaped.");
+        Assert.True(leaked.IsEmpty,
+            $"Expected no control ops forwarded after teardown, but {leaked.Count} '{CoreIterationError}' exceptions escaped.");
     }
 }

--- a/Tests/PowerSync/PowerSync.Common.Tests/Client/Sync/SyncIterationTeardownTests.cs
+++ b/Tests/PowerSync/PowerSync.Common.Tests/Client/Sync/SyncIterationTeardownTests.cs
@@ -20,50 +20,11 @@ using PowerSync.Common.Tests.Utils.Sync;
 /// </summary>
 public class SyncIterationTeardownTests
 {
-    /// <summary>
-    /// Establishes the core contract the teardown behaviour relies on: once the
-    /// iteration has been stopped, forwarding any further control op throws.
-    /// </summary>
-    [Fact]
-    public async Task ControlOpAfterStopThrows()
-    {
-        var syncService = new MockSyncService();
-        var db = syncService.CreateDatabase();
-        await db.Init();
-
-        try
-        {
-            Task<string> Control(string op, object? payload = null) =>
-                db.WriteTransaction(async tx =>
-                    (await tx.Get<ControlRow>("SELECT powersync_control(?, ?) AS r", [op, payload])).r!);
-
-            var startPayload = JsonConvert.SerializeObject(new
-            {
-                parameters = new Dictionary<string, object>(),
-                active_streams = Array.Empty<object>(),
-                include_defaults = true,
-                app_metadata = new Dictionary<string, string>()
-            });
-
-            await Control("start", startPayload);
-            await Control("stop");
-
-            var ex = await Assert.ThrowsAnyAsync<Exception>(() => Control("line_text", "{}"));
-            Assert.Contains("No iteration is active", ex.Message);
-        }
-        finally
-        {
-            syncService.Close();
-            await db.Close();
-            DatabaseUtils.CleanDb(db.Database.Name);
-        }
-    }
 
     /// <summary>
     /// Disconnecting while sync lines are still queued must end the iteration
-    /// cleanly: queued control ops are dropped rather than forwarded to a core
-    /// that no longer has an active iteration. No control exception should escape
-    /// the iteration task, even across many rapid reconnect cycles.
+    /// cleanly, queued control ops are dropped rather than forwarded to a core
+    /// that no longer has an active iteration.
     /// </summary>
     [Fact(Timeout = 60000)]
     public async Task DisconnectWithQueuedLinesEndsCleanly()

--- a/Tests/PowerSync/PowerSync.Common.Tests/Client/Sync/SyncIterationTeardownTests.cs
+++ b/Tests/PowerSync/PowerSync.Common.Tests/Client/Sync/SyncIterationTeardownTests.cs
@@ -1,0 +1,126 @@
+namespace PowerSync.Common.Tests.Client.Sync;
+
+using System.Collections.Concurrent;
+
+using Newtonsoft.Json;
+
+using PowerSync.Common.Client;
+using PowerSync.Common.Tests.Utils;
+using PowerSync.Common.Tests.Utils.Sync;
+
+/// <summary>
+/// Verifies how a sync iteration tears down: once an iteration has ended, no
+/// further control op is forwarded to the core. The core rejects control ops
+/// after its iteration stops (see <see cref="ControlOpAfterStopThrows"/>), so
+/// forwarding a queued op after teardown would surface an unhandled exception.
+/// The control loop must therefore stop forwarding as soon as the iteration
+/// closes.
+///
+/// dotnet test -v n --framework net8.0 --filter "SyncIterationTeardownTests"
+/// </summary>
+public class SyncIterationTeardownTests
+{
+    /// <summary>
+    /// Establishes the core contract the teardown behaviour relies on: once the
+    /// iteration has been stopped, forwarding any further control op throws.
+    /// </summary>
+    [Fact]
+    public async Task ControlOpAfterStopThrows()
+    {
+        var syncService = new MockSyncService();
+        var db = syncService.CreateDatabase();
+        await db.Init();
+
+        try
+        {
+            Task<string> Control(string op, object? payload = null) =>
+                db.WriteTransaction(async tx =>
+                    (await tx.Get<ControlRow>("SELECT powersync_control(?, ?) AS r", [op, payload])).r!);
+
+            var startPayload = JsonConvert.SerializeObject(new
+            {
+                parameters = new Dictionary<string, object>(),
+                active_streams = Array.Empty<object>(),
+                include_defaults = true,
+                app_metadata = new Dictionary<string, string>()
+            });
+
+            await Control("start", startPayload);
+            await Control("stop");
+
+            var ex = await Assert.ThrowsAnyAsync<Exception>(() => Control("line_text", "{}"));
+            Assert.Contains("No iteration is active", ex.Message);
+        }
+        finally
+        {
+            syncService.Close();
+            await db.Close();
+            DatabaseUtils.CleanDb(db.Database.Name);
+        }
+    }
+
+    /// <summary>
+    /// Disconnecting while sync lines are still queued must end the iteration
+    /// cleanly: queued control ops are dropped rather than forwarded to a core
+    /// that no longer has an active iteration. No control exception should escape
+    /// the iteration task, even across many rapid reconnect cycles.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task DisconnectWithQueuedLinesEndsCleanly()
+    {
+        var unobserved = new ConcurrentBag<string>();
+        void Handler(object? sender, UnobservedTaskExceptionEventArgs e)
+        {
+            foreach (var ex in e.Exception.Flatten().InnerExceptions)
+            {
+                unobserved.Add(ex.Message);
+            }
+            e.SetObserved();
+        }
+
+        TaskScheduler.UnobservedTaskException += Handler;
+        try
+        {
+            for (int i = 0; i < 12; i++)
+            {
+                var syncService = new MockSyncService();
+                var db = syncService.CreateDatabase();
+                await db.Init();
+
+                await db.Connect(new TestConnector());
+
+                // Establish + rapidly enqueue lines so the control queue backs up.
+                syncService.PushLine(MockDataFactory.Checkpoint(lastOpId: 0, buckets: []));
+                for (int j = 0; j < 30; j++)
+                {
+                    syncService.PushLine(MockDataFactory.Checkpoint(lastOpId: j, buckets: []));
+                }
+
+                // Disconnect while lines are still queued (e.g. socket death / reconnect).
+                await db.Disconnect();
+
+                syncService.Close();
+                await db.Close();
+                DatabaseUtils.CleanDb(db.Database.Name);
+            }
+
+            // Surface any unobserved task exceptions.
+            for (int k = 0; k < 5; k++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                await Task.Delay(50);
+            }
+        }
+        finally
+        {
+            TaskScheduler.UnobservedTaskException -= Handler;
+        }
+
+        var leaked = unobserved.Where(m => m.Contains("No iteration is active")).ToList();
+        Assert.True(leaked.Count == 0,
+            $"Expected no control ops forwarded after teardown, but {leaked.Count} 'No iteration is active' exceptions escaped.");
+    }
+
+    private record ControlRow(string? r);
+}


### PR DESCRIPTION
This ports [similar changes from the JS SDK](https://github.com/powersync-ja/powersync-js/pull/951) (itself a port of [powersync.dart#410](https://github.com/powersync-ja/powersync.dart/pull/410)) to the sync client in the .NET SDK.

Addresses https://github.com/powersync-ja/powersync-dotnet/issues/81.

When a sync stream closed, a few already-queued messages could still be sent to the sync core after it had stopped listening. Those turned into `No iteration is active` errors that surfaced in crash reporting without the app being
able to catch them.

The iteration now processes everything in one sequential loop rather than alongside a background task, so once a stream ends nothing further is sent. Also uses the core's newer `connection` command to report connect/disconnect state instead of setting it manually, and makes stream read failures flow into the normal retry path.

## AI disclosure

This PR was created with the help of Claude Opus 4.8. Help constitutes assistance in research, planning, and rough outline of implementation. Beyond having a hand in the implementation, I have also manually tested this work.
