### PR TITLE
Update core extension version to 0.5.3

### DIFF
--- a/PowerSync/PowerSync.Common/CHANGELOG.md
+++ b/PowerSync/PowerSync.Common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # PowerSync.Common Changelog
 
+## 0.1.5
+
+- Update the PowerSync SQLite core extension to 0.5.3.
+    - Fix a transaction affecting both insert-only and regular tables being recorded as two transaction ids.
+    - Improve error messages for errors originating from the core extension.
+
 ## 0.1.4
 
 - Update the PowerSync SQLite core extension to 0.5.2.

--- a/PowerSync/PowerSync.Maui/CHANGELOG.md
+++ b/PowerSync/PowerSync.Maui/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PowerSync.Maui Changelog
 
+## 0.1.5
+
+- Upstream PowerSync.Common version bump (See Powersync.Common changelog 0.1.5 for more information)
+
 ## 0.1.4
 
 - Upstream PowerSync.Common version bump (See Powersync.Common changelog 0.1.4 for more information)

--- a/Tools/Setup/Setup.cs
+++ b/Tools/Setup/Setup.cs
@@ -10,7 +10,7 @@ using System.IO.Compression;
 /// </summary>
 public class PowerSyncSetup
 {
-    private const string VERSION = "0.5.2";
+    private const string VERSION = "0.5.3";
 
     private const string GITHUB_BASE_URL = $"https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v{VERSION}";
 


### PR DESCRIPTION
This updates the core extension to version 0.5.3 ([release notes](https://github.com/powersync-ja/powersync-sqlite-core/releases/tag/v0.5.3)).